### PR TITLE
Cleaned up api and adopted more RESTful conventions

### DIFF
--- a/imgfac/rest/imagefactory.py
+++ b/imgfac/rest/imagefactory.py
@@ -19,25 +19,17 @@ from traceback import *
 from imgfac.BuildDispatcher import BuildDispatcher
 from imgfac.JobRegistry import JobRegistry
 
+sys.path.append('%s/imgfac/rest' % sys.path[0])
 
 rest_api = Bottle()
 
 @rest_api.get('/imagefactory')
 def api_info():
-    """
-    TODO: Docstring for api_info 
-
-    @return TODO
-    """
-    return {'name':'imagefactory', 'version':'0.1'}
+    return {'name':'imagefactory', 'version':'1.0'}
 
 @rest_api.post('/imagefactory/images')
-def new_image():
-    """
-    TODO: Docstring for new_image 
-
-    @return TODO
-    """
+@rest_api.put('/imagefactory/images/:image_id')
+def build_image(image_id=None):
     help_txt = """To build a new target image, supply a template and list of targets to build for.
 To import an image, supply target_name, provider_name, target_identifier, and image_descriptor."""
     # build image arguments
@@ -48,16 +40,38 @@ To import an image, supply target_name, provider_name, target_identifier, and im
     provider_name = request.forms.get('provider_name')
     target_identifier = request.forms.get('target_identifier')
     image_descriptor = request.forms.get('image_descriptor')
-    image_id = request.forms.get('image_id')
-    build_id = request.forms.get('build_id')
 
     if(template and targets):
         try:
-            return build_image()
+            jobs = BuildDispatcher().build_image_for_targets(image_id, None, template, targets.split(','))
+            if(image_id):
+                base_url = request.url
+            else:
+                image_id = jobs[0].image_id
+                base_url = '%s/%s' % (request.url, image_id)
+
+            image = {'_type':'image','id':image_id,'href':base_url}
+            build_id = jobs[0].build_id
+            build = {'_type':'build',
+                        'id':build_id,
+                        'href':'%s/builds/%s' % (base_url, build_id)}
+            target_images = []
+            for job in jobs:
+                target_image_id = job.new_image_id
+                target_images.append({'_type':'target_image',
+                                        'id':target_image_id,
+                                        'href':'%s/builds/%s/target_images/%s' % (base_url, build_id, target_image_id)})
+            build['target_images'] = target_images
+            image['build'] = build
+
+            response.status = 202
+            return image
         except Exception as e:
-            response.status = 500
-            return {'exception':e, 'traceback':format_tb(sys.exc_info()[2])}
+            return _response_for_exception(e)
+
     elif(target_name and provider_name and target_identifier and image_descriptor):
+        image_id = request.forms.get('image_id')
+        build_id = request.forms.get('build_id')
         try:
             import_result = BuildDispatcher().import_image(image_id,
                                                             build_id,
@@ -65,135 +79,135 @@ To import an image, supply target_name, provider_name, target_identifier, and im
                                                             image_descriptor,
                                                             target_name,
                                                             provider_name)
-            response_body = {'image_id':import_result[0],
-                                'build_id':import_result[1],
-                                'target_image_id':import_result[2],
-                                'provider_image_id':import_result[3]}
-            return response_body
+            image_id = import_result[0]
+            base_url = '%s/%s' % (request.url, image_id)
+            image = {'_type':'image','id':image_id,'href':base_url}
+            build_id = import_result[1]
+            build = {'_type':'build',
+                        'id':build_id,
+                        'href':'%s/builds/%s' % (base_url, build_id)}
+            target_image_id = import_result[2]
+            target_image = {'_type':'target_image',
+                            'id':target_image_id,
+                            'href':'%s/builds/%s/target_images/%s' % (base_url, build_id, target_image_id)}
+            provider_image_id = import_result[3]
+            provider_image = {'_type':'provider_image',
+                                'id':provider_image_id,
+                                'href':'%s/builds/%s/target_images/%s/provider_images/%s' % (base_url, build_id, target_image_id, provider_image_id)}
+
+            target_image['provider_images'] = (provider_image,)
+            build['target_images'] = (target_image,)
+            image['build'] = build
+
+            response.status = 200
+            return image
         except Exception as e:
-            response.status = 500
-            return {'exception':e, 'traceback':format_tb(sys.exc_info()[2])}
+            return _response_for_exception(e)
     else:
         response.status = 400
         return help_txt
 
-@rest_api.put('/imagefactory/images/:image_id')
-@rest_api.put('/imagefactory/images/:image_id/builds/:build_id')
-def build_image(image_id=None, build_id=None):
-    """
-    TODO: Docstring for build_image
-    
-    @param image_id TODO
-    @param build_id TODO
-
-    @return TODO
-    """
-    template = request.forms.get('template')
-    targets = request.forms.get('targets')
-
-    try:
-        jobs = BuildDispatcher().build_image_for_targets(image_id, build_id, template, targets.split(','))
-        response.status = 202
-        return _response_body_for_jobs(jobs)
-    except Exception as e:
-        response.status = 500
-        return {'exception':e, 'traceback':format_tb(sys.exc_info()[2])}
-
-@rest_api.post('/imagefactory/images/:image_id/builds')
-@rest_api.post('/imagefactory/images/:image_id/builds/:build_id')
-def push_image(image_id, build_id=None):
-    """
-    TODO: Docstring for push_image
-    
-    @param image_id TODO
-    @param build_id TODO
-
-    @return TODO
-    """
-    providers = request.forms.get('providers')
+@rest_api.post('/imagefactory/images/:image_id/builds/:build_id/target_image/:target_image_id/provider_images')
+def push_image(image_id, build_id, target_image_id):
+    provider = request.forms.get('provider')
     credentials = request.forms.get('credentials')
 
-    if(providers and credentials):
+    if(provider and credentials and (len(provider.split(',')) == 1)):
         try:
-            jobs = BuildDispatcher().push_image_to_providers(image_id, build_id, providers, credentials)
             response.status = 202
-            return _response_body_for_jobs(jobs)
+            job = BuildDispatcher().push_image_to_providers(image_id, build_id, provider, credentials)[0]
+
+            provider_image_id = job.new_image_id
+            return {'_type':'provider_image',
+                    'id':provider_image_id,
+                    'href':'%s/%s' % (request.url, provider_image_id)}
+
         except Exception as e:
-            response.status = 500
-            return {'exception':e, 'traceback':format_tb(sys.exc_info()[2])}
+            return _response_for_exception(e)
     else:
         response.status = 400
-        return 'To push an image, a list of providers and credentials must be supplied.'
+        return 'To push an image, a provider id and provider credentials must be supplied.'
 
-def _response_body_for_jobs(jobs):
-    """
-    TODO: Docstring for _response_body_for_jobs
-    
-    @param jobs List of BuildJob objects
+def _response_for_exception(exception):
+    response.status = 500
+    return {'exception':e, 'traceback':format_tb(sys.exc_info()[2])}
 
-    @return Dict with keys 'image_id', 'build_id', and 'builders'
-    """
-    response_body = {}
-    response_body.update({'image_id':jobs[0].image_id,'build_id':jobs[0].build_id})
-    builders = []
-    for job in jobs:
-        builder_id = job.new_image_id
-        builder_url = '%s://%s%s/%s' % (request.urlparts[0], request.urlparts[1], builders_route, builder_id)
-        builders.append({'target':job.target, 'id':builder_id, 'href':builder_url})
-    response_body.update({'builders':builders})
-    return response_body
-
-# using this var for now since I cannot get Bottle.get_url() to work -sloranz 20110909
-builders_route = '/imagefactory/builders'
-@rest_api.get(builders_route)
-def list_():
-    """
-    TODO: Docstring for list_ 
-
-    @return TODO
-    """
-    response_body = {}
+@rest_api.get('/imagefactory/builders')
+def list_builders():
+    collection = {'_type':'builders','href':request.url}
     jobs = JobRegistry().jobs
+    builders = []
+    for builder_id in jobs.keys():
+        job = jobs[builder_id]
+        builders.append({'completed':job.percent_complete,
+                         'status':job.status,
+                         'operation':job.operation,
+                         'target':job.target,
+                         '_type':'builder',
+                         'id':builder_id,
+                         'href':'%s/%s' % (request.url, builder_id)})
 
-    for key in jobs.keys():
-        job = jobs[key]
-        response_body.update({key:{'completed':job.percent_complete, 'status':job.status, 'type':job.operation, 'target':job.target}})
+    collection['builders'] = builders
+    return collection
 
-    return response_body
+@rest_api.get('/imagefactory/builders/:builder_id')
+@rest_api.get('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id')
+@rest_api.get('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images/:provider_image_id')
+def builder_detail(builder_id=None, image_id=None, build_id=None, target_image_id=None, provider_image_id=None):
+    if(builder_id):
+        _id = builder_id
+        _type = 'builder'
+    elif(target_image_id and provider_image_id):
+        _id = provider_image_id
+        _type = 'provider_image_status'
+    elif(target_image_id):
+        _id = target_image_id
+        _type = 'target_image_status'
+    else:
+        response.status = 404
+        return
 
-@rest_api.route('/imagefactory/builders/:builder_id', name='builder_detail')
-def builder_detail(builder_id):
-    """
-    TODO: Docstring for builder_detail
-    
-    @param builder_id TODO 
+    job = JobRegistry().jobs[_id]
+    return {'completed':job.percent_complete,
+            'status':job.status,
+            'operation':job.operation,
+            'target':job.target,
+            'href':request.url,
+            'id':_id,
+            '_type':_type}
 
-    @return TODO
-    """
-    job = JobRegistry().jobs[builder_id]
-    return {'completed':job.percent_complete, 'status':job.status, 'type':job.operation, 'target':job.target}
+@rest_api.get('/imagefactory/builders/:builder_id/status')
+@rest_api.get('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/status')
+@rest_api.get('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images/:provider_image_id/status')
+def builder_status(builder_id=None, image_id=None, build_id=None, target_image_id=None, provider_image_id=None):
+    if(builder_id):
+        _id = builder_id
+        _type = 'builder_status'
+    elif(target_image_id and provider_image_id):
+        _id = provider_image_id
+        _type = 'provider_image_status'
+    elif(target_image_id):
+        _id = target_image_id
+        _type = 'target_image_status'
+    else:
+        response.status = 404
+        return
 
-@rest_api.route('/imagefactory/builders/:builder_id/status', name='builder_status')
-def builder_status(builder_id):
-    """
-    TODO: Docstring for builder_status
-    
-    @param builder_id TODO 
-
-    @return TODO
-    """
-    job = JobRegistry().jobs[builder_id]
-    return job.status
+    job = JobRegistry().jobs[_id]
+    return {'_type':_type,
+            'id':_id,
+            'href':request.url,
+            'status':job.status}
 
 # Things we have not yet implemented
 @rest_api.route('/imagefactory/images', method=('GET','DELETE'))
 @rest_api.route('/imagefactory/images/:image_id', method=('GET','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds', method=('GET','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds/:build_id', method=('GET','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_image', method=('GET','PUT','POST','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_image/:target_image_id', method=('GET','PUT','POST','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_image/:target_image_id/provider_image', method=('GET','PUT','POST','DELETE'))
-@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_image/:target_image_id/provider_image/:provider_image_id', method=('GET','PUT','POST','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds', method=('GET','POST','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id', method=('GET','PUT','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images', method=('GET','POST','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id', method=('PUT','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images', method=('GET','DELETE'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images/:provider_image_id', method=('PUT','DELETE'))
 @rest_api.route('/imagefactory/targets', method=('GET'))
 @rest_api.route('/imagefactory/targets/:target_name', method=('GET'))
 @rest_api.route('/imagefactory/targets/:target_name/providers', method=('GET','POST','DELETE'))
@@ -209,6 +223,11 @@ def method_not_implemented(**kw):
 @rest_api.route('/imagefactory/images', method=('PUT'))
 @rest_api.route('/imagefactory/images/:image_id', method=('POST'))
 @rest_api.route('/imagefactory/images/:image_id/builds', method=('PUT'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id', method=('POST'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images', method=('PUT'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id', method=('POST'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images', method=('PUT'))
+@rest_api.route('/imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images/:provider_image_id', method=('POST'))
 @rest_api.route('/imagefactory/targets', method=('PUT','POST','DELETE'))
 @rest_api.route('/imagefactory/targets/:target_name', method=('PUT','POST','DELETE'))
 @rest_api.route('/imagefactory/targets/:target_name/providers', method=('PUT'))


### PR DESCRIPTION
- responses now include REST metadata such as _type, id, and href
- moved pushing to /imagefactory/images/:image_id/builds/:build_id/target_images/:target_image_id/provider_images
- this only accepts one provider id and creates a single provider_image, which is more in line with POST to collection in REST
- building now returns an "image" which has a build which, in turn, has target_images
- doing a GET on a target_image or provider_image now gets the detail of the builder of that object. appending /status gets the status of the builder.

Signed-off-by: Steve Loranz sloranz@redhat.com
