### PR TITLE
Added ability to accept requests with Content-Type of application/json

### DIFF
--- a/imgfac/rest/bottle.py
+++ b/imgfac/rest/bottle.py
@@ -15,7 +15,7 @@ License: MIT (see LICENSE.txt for details)
 from __future__ import with_statement
 
 __author__ = 'Marcel Hellkamp'
-__version__ = '0.9.6'
+__version__ = '0.10.dev'
 __license__ = 'MIT'
 
 import base64
@@ -40,8 +40,13 @@ import warnings
 from Cookie import SimpleCookie
 from tempfile import TemporaryFile
 from traceback import format_exc
-from urllib import urlencode, quote as urlquote, unquote as urlunquote
-from urlparse import urlunsplit, urljoin, SplitResult as UrlSplitResult
+from urlparse import urljoin, SplitResult as UrlSplitResult
+
+# Workaround for a bug in some versions of lib2to3 (fixed on CPython 2.7 and 3.2)
+import urllib
+urlencode = urllib.urlencode
+urlquote = urllib.quote
+urlunquote = urllib.unquote
 
 try: from collections import MutableMapping as DictMixin
 except ImportError: # pragma: no cover
@@ -55,16 +60,21 @@ try: import cPickle as pickle
 except ImportError: # pragma: no cover
     import pickle
 
-try: from json import dumps as json_dumps
+try: from json import dumps as json_dumps, loads as json_lds
 except ImportError: # pragma: no cover
-    try: from simplejson import dumps as json_dumps
+    try: from simplejson import dumps as json_dumps, loads as json_lds
     except ImportError: # pragma: no cover
-        try: from django.utils.simplejson import dumps as json_dumps
+        try: from django.utils.simplejson import dumps as json_dumps, loads as json_lds
         except ImportError: # pragma: no cover
-            json_dumps = None
+            def json_dumps(data):
+                raise ImportError("JSON support requires Python 2.6 or simplejson.")
+            json_lds = json_dumps
 
+py3k = sys.version_info >= (3,0,0)
 NCTextIOWrapper = None
-if sys.version_info >= (3,0,0): # pragma: no cover
+
+if py3k: # pragma: no cover
+    json_loads = lambda s: json_lds(touni(s))
     # See Request.POST
     from io import BytesIO
     def touni(x, enc='utf8', err='strict'):
@@ -77,6 +87,7 @@ if sys.version_info >= (3,0,0): # pragma: no cover
                 the wrapped buffer. This subclass keeps it open. '''
             def close(self): pass
 else:
+    json_loads = json_lds
     from StringIO import StringIO as BytesIO
     bytes = str
     def touni(x, enc='utf8', err='strict'):
@@ -88,7 +99,7 @@ def tob(data, enc='utf8'):
     return data.encode(enc) if isinstance(data, unicode) else bytes(data)
 
 # Convert strings and unicode to native strings
-if sys.version_info >= (3,0,0):
+if  py3k:
     tonat = touni
 else:
     tonat = tob
@@ -132,10 +143,21 @@ class DictProperty(object):
         if self.read_only: raise AttributeError("Read-Only property.")
         del getattr(obj, self.attr)[self.key]
 
-def cached_property(func):
-    ''' A property that, if accessed, replaces itself with the computed
-        value. Subsequent accesses won't call the getter again. '''
-    return DictProperty('__dict__')(func)
+class CachedProperty(object):
+    ''' A property that is only computed once per instance and then replaces
+        itself with an ordinary attribute. Deleting the attribute resets the
+        property. '''
+
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, cls):
+        if obj is None: return self
+        value = obj.__dict__[self.func.__name__] = self.func(obj)
+        return value
+
+cached_property = CachedProperty
+
 
 class lazy_attribute(object): # Does not need configuration -> lower-case name
     ''' A property that caches itself to the class object. '''
@@ -162,6 +184,8 @@ class BottleException(Exception):
     """ A base class for exceptions used by bottle. """
     pass
 
+
+#TODO: These should subclass BaseRequest
 
 class HTTPResponse(BottleException):
     """ Used to break execution and immediately finish the response """
@@ -254,11 +278,8 @@ class Router(object):
         self.static = {}  # Cache for static routes: {path: {method: target}}
         self.dynamic = [] # Cache for dynamic routes. See _compile()
 
-    def add(self, rule, method, target, name=None, static=False):
+    def add(self, rule, method, target, name=None):
         ''' Add a new route or replace the target for an existing route. '''
-        if static:
-            depr("Use a backslash to escape ':' in routes.") # 0.9
-            rule = rule.replace(':','\\:')
 
         if rule in self.routes:
             self.routes[rule][method.upper()] = target
@@ -326,7 +347,7 @@ class Router(object):
             match = combined.match(path)
             if not match: continue
             gpat, match = rules[match.lastindex - 1]
-            return match, gpat.match(path).groupdict() if gpat else {}
+            return match, gpat(path).groupdict() if gpat else {}
         # Lazy-check if we are really in a warm state. If yes, stop here.
         if self.static or self.dynamic or not self.routes: return None, {}
         # Cold state: We have not compiled any rules yet. Do so and try again.
@@ -357,7 +378,7 @@ class Router(object):
                 continue
             gpat = self._compile_pattern(rule)
             fpat = re.sub(r'(\\*)(\(\?P<[^>]*>|\((?!\?))', fpat_sub, gpat.pattern)
-            gpat = gpat if gpat.groupindex else None
+            gpat = gpat.match if gpat.groupindex else None
             try:
                 combined = '%s|(%s)' % (self.dynamic[-1][0].pattern, fpat)
                 self.dynamic[-1] = (re.compile(combined), self.dynamic[-1][1])
@@ -378,6 +399,86 @@ class Router(object):
         return re.compile('^%s$'%out)
 
 
+class Route(object):
+    ''' This class wraps a route callback along with route specific metadata and
+        configuration and applies Plugins on demand. '''
+
+    def __init__(self, app, rule, method, callback, name=None,
+                 plugins=None, skiplist=None, **config):
+        #: The application this route is installed to.
+        self.app = app
+        #: The path-rule string (e.g. ``/wiki/:page``).
+        self.rule = rule
+        #: The HTTP method as a string (e.g. ``GET``).
+        self.method = method
+        #: The original callback with no plugins applied. Useful for introspection.
+        self.callback = callback
+        #: The name of the route (if specified) or ``None``.
+        self.name = name or None
+        #: A list of route-specific plugins (see :meth:`Bottle.route`).
+        self.plugins = plugins or []
+        #: A list of plugins to not apply to this route (see :meth:`Bottle.route`).
+        self.skiplist = skiplist or []
+        #: Additional keyword arguments passed to the :meth:`Bottle.route`
+        #: decorator are stored in this dictionary. Used for route-specific
+        #: plugin configuration and meta-data.
+        self.config = ConfigDict(config)
+
+    def __call__(self, *a, **ka):
+        depr("Some APIs changed to return Route() instances instead of"\
+             " callables. Make sure to use the Route.call method and not to"\
+             " call Route instances directly.")
+        return self.call(*a, **ka)
+
+    @cached_property
+    def call(self):
+        ''' The route callback with all plugins applied. This property is
+            created on demand and then cached to speed ub subsequent requests.'''
+        return self._make_callback()
+
+    def reset(self):
+        ''' Forget any cached values. The next time :attr:`call` is accessed,
+            all plugins are re-applied. '''
+        self.__dict__.pop('call', None)
+
+    def prepare(self):
+        ''' Do all on-demand work immediately (useful for debugging).'''
+        self.call
+
+    @property
+    def _context(self):
+        depr('Switch to Plugin API v2 and access the Route object directly.')
+        return dict(rule=self.rule, method=self.method, callback=self.callback,
+                    name=self.name, app=self.app, config=self.config,
+                    apply=self.plugins, skip=self.skiplist)
+
+    def all_plugins(self):
+        ''' Yield all Plugins affecting this route. '''
+        unique = set()
+        for p in reversed(self.app.plugins + self.plugins):
+            if True in self.skiplist: break
+            name = getattr(p, 'name', False)
+            if name and (name in self.skiplist or name in unique): continue
+            if p in self.skiplist or type(p) in self.skiplist: continue
+            if name: unique.add(name)
+            yield p
+
+    def _make_callback(self):
+        callback = self.callback
+        for plugin in self.all_plugins():
+            try:
+                if hasattr(plugin, 'apply'):
+                    api = getattr(plugin, 'api', 1)
+                    context = self if api > 1 else self._context
+                    callback = plugin.apply(callback, context)
+                else:
+                    callback = plugin(callback)
+            except RouteReset: # Try again with changed configuration.
+                return self._make_callback()
+            functools.update_wrapper(callback, self.callback)
+        return callback
+
+
 
 
 
@@ -394,27 +495,21 @@ class Bottle(object):
         """ Create a new bottle instance.
             You usually don't do that. Use `bottle.app.push()` instead.
         """
-        self.routes = [] # List of installed routes including metadata.
-        self.router = Router() # Maps requests to self.route indices.
-        self.ccache = {} # Cache for callbacks with plugins applied.
-
+        self.routes = [] # List of installed :class:`Route` instances.
+        self.router = Router() # Maps requests to :class:`Route` instances.
         self.plugins = [] # List of installed plugins.
 
         self.mounts = {}
         self.error_handler = {}
         #: If true, most exceptions are catched and returned as :exc:`HTTPError`
         self.catchall = catchall
-        self.config = config or {}
-        self.serve = True
-        # Default plugins
-        self.hooks = self.install(HooksPlugin())
-        self.typefilter = self.install(TypeFilterPlugin())
+        self.config = ConfigDict(config or {})
+        #: An instance of :class:`HooksPlugin`. Empty by default.
+        self.hooks = HooksPlugin()
+        self.install(self.hooks)
         if autojson:
             self.install(JSONPlugin())
         self.install(TemplatePlugin())
-
-    def optimize(self, *a, **ka):
-        depr("Bottle.optimize() is obsolete.")
 
     def mount(self, app, prefix, **options):
         ''' Mount an application to a specific URL prefix. The prefix is added
@@ -441,14 +536,11 @@ class Bottle(object):
         @self.route('/%s/:#.*#' % prefix, **options)
         def mountpoint():
             request.path_shift(path_depth)
-            return app._handle(request.environ)
-
-    def add_filter(self, ftype, func):
-        depr("Filters are deprecated and can be replaced with plugins.") #0.9
-        self.typefilter.add(ftype, func)
+            # TODO: This sucks. Make it better.
+            return app._cast(app._handle(request.environ), request, response)
 
     def install(self, plugin):
-        ''' Add a plugin to the list of plugins and prepare it for beeing
+        ''' Add a plugin to the list of plugins and prepare it for being
             applied to all routes of this application. A plugin may be a simple
             decorator or an object that implements the :class:`Plugin` API.
         '''
@@ -460,11 +552,10 @@ class Bottle(object):
         return plugin
 
     def uninstall(self, plugin):
-        ''' Uninstall plugins. Pass an instance to remove a specific plugin.
-            Pass a type object to remove all plugins that match that type.
-            Subclasses are not removed. Pass a string to remove all plugins with
-            a matching ``name`` attribute. Pass ``True`` to remove all plugins.
-            The list of affected plugins is returned. '''
+        ''' Uninstall plugins. Pass an instance to remove a specific plugin, a type
+            object to remove all plugins that match that type, a string to remove
+            all plugins with a matching ``name`` attribute or ``True`` to remove all
+            plugins. Return the list of removed plugins. '''
         removed, remove = [], plugin
         for i, plugin in list(enumerate(self.plugins))[::-1]:
             if remove is True or remove is plugin or remove is type(plugin) \
@@ -475,15 +566,17 @@ class Bottle(object):
         if removed: self.reset()
         return removed
 
-    def reset(self, id=None):
+    def reset(self, route=None):
         ''' Reset all routes (force plugins to be re-applied) and clear all
-            caches. If an ID is given, only that specific route is affected. '''
-        if id is None: self.ccache.clear()
-        else: self.ccache.pop(id, None)
+            caches. If an ID or route object is given, only that specific route
+            is affected. '''
+        if route is None: routes = self.routes
+        elif isinstance(route, Route): routes = [route]
+        else: routes = [self.routes[route]]
+        for route in routes: route.reset()
         if DEBUG:
-            for route in self.routes:
-                if route['id'] not in self.ccache:
-                    self.ccache[route['id']] = self._build_callback(route)
+            for route in routes: route.prepare()
+        self.hooks.trigger('app_reset')
 
     def close(self):
         ''' Close the application and all installed plugins. '''
@@ -492,45 +585,11 @@ class Bottle(object):
         self.stopped = True
 
     def match(self, environ):
-        """ (deprecated) Search for a matching route and return a
-            (callback, urlargs) tuple.
-            The first element is the associated route callback with plugins
-            applied. The second value is a dictionary with parameters extracted
-            from the URL. The :class:`Router` raises :exc:`HTTPError` (404/405)
-            on a non-match."""
-        depr("This method will change semantics in 0.10.")
-        return self._match(environ)
-        
-    def _match(self, environ):
-        handle, args = self.router.match(environ)
-        environ['route.handle'] = handle # TODO move to router?
-        environ['route.url_args'] = args
-        try:
-            return self.ccache[handle], args
-        except KeyError:
-            config = self.routes[handle]
-            callback = self.ccache[handle] = self._build_callback(config)
-            return callback, args
-
-    def _build_callback(self, config):
-        ''' Apply plugins to a route and return a new callable. '''
-        wrapped = config['callback']
-        plugins = self.plugins + config['apply']
-        skip    = config['skip']
-        try:
-            for plugin in reversed(plugins):
-                if True in skip: break
-                if plugin in skip or type(plugin) in skip: continue
-                if getattr(plugin, 'name', True) in skip: continue
-                if hasattr(plugin, 'apply'):
-                    wrapped = plugin.apply(wrapped, config)
-                else:
-                    wrapped = plugin(wrapped)
-                if not wrapped: break
-                functools.update_wrapper(wrapped, config['callback'])
-            return wrapped
-        except RouteReset: # A plugin may have changed the config dict inplace.
-            return self._build_callback(config) # Apply all plugins again.
+        """ Search for a matching route and return a (:class:`Route` , urlargs)
+            tuple. The second value is a dictionary with parameters extracted
+            from the URL. Raise :exc:`HTTPError` (404/405) on a non-match."""
+        route, args = self.router.match(environ)
+        return route, args
 
     def get_url(self, routename, **kargs):
         """ Return a string that matches a named route """
@@ -566,31 +625,20 @@ class Bottle(object):
             configuration and passed to plugins (see :meth:`Plugin.apply`).
         """
         if callable(path): path, callback = None, path
-
         plugins = makelist(apply)
         skiplist = makelist(skip)
-        if 'decorate' in config:
-            depr("The 'decorate' parameter was renamed to 'apply'") # 0.9
-            plugins += makelist(config.pop('decorate'))
-        if config.pop('no_hooks', False):
-            depr("The no_hooks parameter is no longer used. Add 'hooks' to the"\
-                 " list of skipped plugins instead.") # 0.9
-            skiplist.append('hooks')
-        static = config.get('static', False) # depr 0.9
-
         def decorator(callback):
+            # TODO: Documentation and tests
+            if isinstance(callback, basestring): callback = load(callback)
             for rule in makelist(path) or yieldroutes(callback):
                 for verb in makelist(method):
                     verb = verb.upper()
-                    cfg = dict(rule=rule, method=verb, callback=callback,
-                               name=name, app=self, config=config,
-                               apply=plugins, skip=skiplist)
-                    self.routes.append(cfg)
-                    cfg['id'] = self.routes.index(cfg)
-                    self.router.add(rule, verb, cfg['id'], name=name, static=static)
-                    if DEBUG: self.ccache[cfg['id']] = self._build_callback(cfg)
+                    route = Route(self, rule, verb, callback, name=name,
+                                  plugins=plugins, skiplist=skiplist, **config)
+                    self.routes.append(route)
+                    self.router.add(rule, verb, route, name=name)
+                    if DEBUG: route.prepare()
             return callback
-
         return decorator(callback) if callback else decorator
 
     def get(self, path=None, method='GET', **options):
@@ -623,14 +671,6 @@ class Bottle(object):
             return func
         return wrapper
 
-    def add_hook(self, name, func):
-        depr("Call Bottle.hooks.add() instead.") #0.9
-        self.hooks.add(name, func)
-
-    def remove_hook(self, name, func):
-        depr("Call Bottle.hooks.remove() instead.") #0.9
-        self.hooks.remove(name, func)
-
     def handle(self, path, method='GET'):
         """ (deprecated) Execute the first matching route callback and return
             the result. :exc:`HTTPResponse` exceptions are catched and returned.
@@ -641,24 +681,25 @@ class Bottle(object):
         if isinstance(path, dict):
             return self._handle(path)
         return self._handle({'PATH_INFO': path, 'REQUEST_METHOD': method.upper()})
-        
+
     def _handle(self, environ):
-        if not self.serve:
-            depr("Bottle.serve will be removed in 0.10.")
-            return HTTPError(503, "Server stopped")
         try:
-            callback, args = self._match(environ)
-            return callback(**args)
+            route, args = self.match(environ)
+            environ['route.handle'] = environ['bottle.route'] = route
+            environ['route.url_args'] = args
+            return route.call(**args)
         except HTTPResponse, r:
             return r
-        except RouteReset: # Route reset requested by the callback or a plugin.
-            del self.ccache[handle]
-            return self._handle(environ) # Try again.
+        except RouteReset:
+            route.reset()
+            return self._handle(environ)
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
         except Exception, e:
             if not self.catchall: raise
-            return HTTPError(500, "Internal Server Error", e, format_exc(10))
+            stacktrace = format_exc(10)
+            environ['wsgi.errors'].write(stacktrace)
+            return HTTPError(500, "Internal Server Error", e, stacktrace)
 
     def _cast(self, out, request, response, peek=None):
         """ Try to convert the parameter into something WSGI compatible and set
@@ -669,7 +710,7 @@ class Bottle(object):
 
         # Empty output is done here
         if not out:
-            response.headers['Content-Length'] = 0
+            response['Content-Length'] = 0
             return []
         # Join lists of byte or unicode strings. Mixed lists are NOT supported
         if isinstance(out, (tuple, list))\
@@ -680,9 +721,10 @@ class Bottle(object):
             out = out.encode(response.charset)
         # Byte Strings are just returned
         if isinstance(out, bytes):
-            response.headers['Content-Length'] = str(len(out))
+            response['Content-Length'] = len(out)
             return [out]
         # HTTPError or HTTPException (recursive, because they may wrap anything)
+        # TODO: Handle these explicitly in handle() or make them iterable.
         if isinstance(out, HTTPError):
             out.apply(response)
             out = self.error_handler.get(out.status, repr)(out)
@@ -732,14 +774,13 @@ class Bottle(object):
             environ['bottle.app'] = self
             request.bind(environ)
             response.bind()
-            out = self._handle(environ)
-            out = self._cast(out, request, response)
+            out = self._cast(self._handle(environ), request, response)
             # rfc2616 section 4.3
-            if response.status in (100, 101, 204, 304) or request.method == 'HEAD':
+            if response.status_code in (100, 101, 204, 304)\
+            or request.method == 'HEAD':
                 if hasattr(out, 'close'): out.close()
                 out = []
-            status = '%d %s' % (response.status, HTTP_CODES[response.status])
-            start_response(status, response.headerlist)
+            start_response(response.status_line, list(response.iter_headers()))
             return out
         except (KeyboardInterrupt, SystemExit, MemoryError):
             raise
@@ -755,6 +796,7 @@ class Bottle(object):
             return [tob(err)]
 
     def __call__(self, environ, start_response):
+        ''' Each instance of :class:'Bottle' is a WSGI application. '''
         return self.wsgi(environ, start_response)
 
 
@@ -767,134 +809,162 @@ class Bottle(object):
 ###############################################################################
 
 
-class Request(threading.local, DictMixin):
-    """ Represents a single HTTP request using thread-local attributes.
-        The Request object wraps a WSGI environment and can be used as such.
-    """
-    def __init__(self, environ=None):
-        """ Create a new Request instance.
+class BaseRequest(DictMixin):
+    """ A wrapper for WSGI environment dictionaries that adds a lot of
+        convenient access methods and properties. Most of them are read-only."""
 
-            You usually don't do this but use the global `bottle.request`
-            instance instead.
-        """
-        self.bind(environ or {},)
+    #: Maximum size of memory buffer for :attr:`body` in bytes.
+    MEMFILE_MAX = 102400
 
-    def bind(self, environ):
-        """ Bind a new WSGI environment.
-
-            This is done automatically for the global `bottle.request`
-            instance on every request.
-        """
+    def __init__(self, environ):
+        """ Wrap a WSGI environ dictionary. """
+        #: The wrapped WSGI environ dictionary. This is the only real attribute.
+        #: All other attributes actually are read-only properties.
         self.environ = environ
-        # These attributes are used anyway, so it is ok to compute them here
-        self.path = '/' + environ.get('PATH_INFO', '/').lstrip('/')
-        self.method = environ.get('REQUEST_METHOD', 'GET').upper()
+        environ['bottle.request'] = self
 
     @property
-    def _environ(self):
-        depr("Request._environ renamed to Request.environ")
-        return self.environ
-
-    def copy(self):
-        ''' Returns a copy of self '''
-        return Request(self.environ.copy())
-
-    def path_shift(self, shift=1):
-        ''' Shift path fragments from PATH_INFO to SCRIPT_NAME and vice versa.
-
-           :param shift: The number of path fragments to shift. May be negative
-                         to change the shift direction. (default: 1)
-        '''
-        script_name = self.environ.get('SCRIPT_NAME','/')
-        self['SCRIPT_NAME'], self.path = path_shift(script_name, self.path, shift)
-        self['PATH_INFO'] = self.path
-
-    def __getitem__(self, key): return self.environ[key]
-    def __delitem__(self, key): self[key] = ""; del(self.environ[key])
-    def __iter__(self): return iter(self.environ)
-    def __len__(self): return len(self.environ)
-    def keys(self): return self.environ.keys()
-    def __setitem__(self, key, value):
-        """ Shortcut for Request.environ.__setitem__ """
-        self.environ[key] = value
-        todelete = []
-        if key in ('PATH_INFO','REQUEST_METHOD'):
-            self.bind(self.environ)
-        elif key == 'wsgi.input': todelete = ('body','forms','files','params')
-        elif key == 'QUERY_STRING': todelete = ('get','params')
-        elif key.startswith('HTTP_'): todelete = ('headers', 'cookies')
-        for key in todelete:
-            if 'bottle.' + key in self.environ:
-                del self.environ['bottle.' + key]
-
-    @DictProperty('environ', 'bottle.urlparts', read_only=True)
-    def urlparts(self):
-        ''' Return a :class:`urlparse.SplitResult` tuple that can be used
-            to reconstruct the full URL as requested by the client.
-            The tuple contains: (scheme, host, path, query_string, fragment).
-            The fragment is always empty because it is not visible to the server.
-        '''
-        env = self.environ
-        http = env.get('wsgi.url_scheme', 'http')
-        host = env.get('HTTP_X_FORWARDED_HOST') or env.get('HTTP_HOST')
-        if not host:
-            # HTTP 1.1 requires a Host-header. This is for HTTP/1.0 clients.
-            host = env.get('SERVER_NAME', '127.0.0.1')
-            port = env.get('SERVER_PORT')
-            if port and port != ('80' if http == 'http' else '443'):
-                host += ':' + port
-        spath = self.environ.get('SCRIPT_NAME','').rstrip('/') + '/'
-        rpath = self.path.lstrip('/')
-        path = urlquote(urljoin(spath, rpath))
-        return UrlSplitResult(http, host, path, env.get('QUERY_STRING'), '')
+    def path(self):
+        ''' The value of ``PATH_INFO`` with exactly one prefixed slash (to fix
+            broken clients and avoid the "empty path" edge case). '''
+        return '/' + self.environ.get('PATH_INFO','').lstrip('/')
 
     @property
-    def url(self):
-        """ Full URL as requested by the client. """
-        return self.urlparts.geturl()
+    def method(self):
+        ''' The ``REQUEST_METHOD`` value as an uppercase string. '''
+        return self.environ.get('REQUEST_METHOD', 'GET').upper()
 
-    @property
-    def fullpath(self):
-        """ Request path including SCRIPT_NAME (if present). """
-        return urlunquote(self.urlparts[2])
-
-    @property
-    def query_string(self):
-        """ The part of the URL following the '?'. """
-        return self.environ.get('QUERY_STRING', '')
-
-    @property
-    def content_length(self):
-        """ Content-Length header as an integer, -1 if not specified """
-        return int(self.environ.get('CONTENT_LENGTH', '') or -1)
-
-    @property
-    def header(self):
-        depr("The Request.header property was renamed to Request.headers")
-        return self.headers
-
-    @DictProperty('environ', 'bottle.headers', read_only=True)
+    @DictProperty('environ', 'bottle.request.headers', read_only=True)
     def headers(self):
-        ''' Request HTTP Headers stored in a :class:`HeaderDict`. '''
+        ''' A :class:`WSGIHeaderDict` that provides case-insensitive access to
+            HTTP request headers. '''
         return WSGIHeaderDict(self.environ)
 
-    @DictProperty('environ', 'bottle.get', read_only=True)
-    def GET(self):
-        """ The QUERY_STRING parsed into an instance of :class:`MultiDict`. """
+    @DictProperty('environ', 'bottle.request.cookies', read_only=True)
+    def cookies(self):
+        """ Cookies parsed into a dictionary. Signed cookies are NOT decoded.
+            Use :meth:`get_cookie` if you expect signed cookies. """
+        raw_dict = SimpleCookie(self.environ.get('HTTP_COOKIE',''))
+        cookies = {}
+        for cookie in raw_dict.itervalues():
+            cookies[cookie.key] = cookie.value
+        return cookies
+
+    def get_cookie(self, key, default=None, secret=None):
+        """ Return the content of a cookie. To read a `Signed Cookie`, the
+            `secret` must match the one used to create the cookie (see
+            :meth:`BaseResponse.set_cookie`). If anything goes wrong (missing
+            cookie or wrong signature), return a default value. """
+        value = self.cookies.get(key)
+        if secret and value:
+            dec = cookie_decode(value, secret) # (key, value) tuple or None
+            return dec[1] if dec and dec[0] == key else default
+        return value or default
+
+    @DictProperty('environ', 'bottle.request.query', read_only=True)
+    def query(self):
+        ''' The :attr:`query_string` parsed into a :class:`FormsDict`. These
+            values are sometimes called "URL arguments" or "GET parameters", but
+            not to be confused with "URL wildcards" as they are provided by the
+            :class:`Router`. '''
         data = parse_qs(self.query_string, keep_blank_values=True)
-        get = self.environ['bottle.get'] = MultiDict()
+        get = self.environ['bottle.get'] = FormsDict()
         for key, values in data.iteritems():
             for value in values:
                 get[key] = value
         return get
 
-    @DictProperty('environ', 'bottle.post', read_only=True)
-    def POST(self):
-        """ The combined values from :attr:`forms` and :attr:`files`. Values are
-            either strings (form values) or instances of
-            :class:`cgi.FieldStorage` (file uploads).
+    @DictProperty('environ', 'bottle.request.forms', read_only=True)
+    def forms(self):
+        """ Form values parsed from an `url-encoded` or `multipart/form-data`
+            encoded POST or PUT request body. The result is retuned as a
+            :class:`FormsDict`. All keys and values are strings. File uploads
+            are stored separately in :attr:`files`. """
+        forms = FormsDict()
+        for name, item in self.POST.iterallitems():
+            if not hasattr(item, 'filename'):
+                forms[name] = item
+        return forms
+
+    @DictProperty('environ', 'bottle.request.params', read_only=True)
+    def params(self):
+        """ A :class:`FormsDict` with the combined values of :attr:`query` and
+            :attr:`forms`. File uploads are stored in :attr:`files`. """
+        params = FormsDict()
+        for key, value in self.query.iterallitems():
+            params[key] = value
+        for key, value in self.forms.iterallitems():
+            params[key] = value
+        return params
+
+    @DictProperty('environ', 'bottle.request.files', read_only=True)
+    def files(self):
+        """ File uploads parsed from an `url-encoded` or `multipart/form-data`
+            encoded POST or PUT request body. The values are instances of
+            :class:`cgi.FieldStorage`. The most important attributes are:
+
+            filename
+                The filename, if specified; otherwise None; this is the client
+                side filename, *not* the file name on which it is stored (that's
+                a temporary file you don't deal with)
+            file
+                The file(-like) object from which you can read the data.
+            value
+                The value as a *string*; for file uploads, this transparently
+                reads the file every time you request the value. Do not do this
+                on big files.
         """
-        post = MultiDict()
+        files = FormsDict()
+        for name, item in self.POST.iterallitems():
+            if hasattr(item, 'filename'):
+                files[name] = item
+        return files
+
+    @DictProperty('environ', 'bottle.request.json', read_only=True)
+    def json(self):
+        ''' If the ``Content-Type`` header is ``application/json``, this
+            property holds the parsed content of the request body. Only requests
+            smaller than :attr:`MEMFILE_MAX` are processed to avoid memory
+            exhaustion. '''
+        if 'application/json' in self.environ.get('CONTENT_TYPE', '') \
+        and 0 < self.content_length < self.MEMFILE_MAX:
+            return json_loads(self.body.read(self.MEMFILE_MAX))
+        return None
+
+    @DictProperty('environ', 'bottle.request.body', read_only=True)
+    def _body(self):
+        maxread = max(0, self.content_length)
+        stream = self.environ['wsgi.input']
+        body = BytesIO() if maxread < self.MEMFILE_MAX else TemporaryFile(mode='w+b')
+        while maxread > 0:
+            part = stream.read(min(maxread, self.MEMFILE_MAX))
+            if not part: break
+            body.write(part)
+            maxread -= len(part)
+        self.environ['wsgi.input'] = body
+        body.seek(0)
+        return body
+
+    @property
+    def body(self):
+        """ The HTTP request body as a seek-able file-like object. Depending on
+            :attr:`MEMFILE_MAX`, this is either a temporary file or a
+            :class:`io.BytesIO` instance. Accessing this property for the first
+            time reads and replaces the ``wsgi.input`` environ variable.
+            Subsequent accesses just do a `seek(0)` on the file object. """
+        self._body.seek(0)
+        return self._body
+
+    #: An alias for :attr:`query`.
+    GET = query
+
+    @DictProperty('environ', 'bottle.request.post', read_only=True)
+    def POST(self):
+        """ The values of :attr:`forms` and :attr:`files` combined into a single
+            :class:`FormsDict`. Values are either strings (form values) or
+            instances of :class:`cgi.FieldStorage` (file uploads).
+        """
+        post = FormsDict()
         safe_env = {'QUERY_STRING':''} # Build a safe environment for cgi
         for key in ('REQUEST_METHOD', 'CONTENT_TYPE', 'CONTENT_LENGTH'):
             if key in self.environ: safe_env[key] = self.environ[key]
@@ -907,182 +977,338 @@ class Request(threading.local, DictMixin):
             post[item.name] = item if item.filename else item.value
         return post
 
-    @DictProperty('environ', 'bottle.forms', read_only=True)
-    def forms(self):
-        """ POST form values parsed into an instance of :class:`MultiDict`.
-
-            This property contains form values parsed from an `url-encoded`
-            or `multipart/form-data` encoded POST request bidy. The values are
-            native strings.
-        """
-        forms = MultiDict()
-        for name, item in self.POST.iterallitems():
-            if not hasattr(item, 'filename'):
-                forms[name] = item
-        return forms
-
-    @DictProperty('environ', 'bottle.files', read_only=True)
-    def files(self):
-        """ File uploads parsed into an instance of :class:`MultiDict`.
-
-            This property contains file uploads parsed from an
-            `multipart/form-data` encoded POST request body. The values are
-            instances of :class:`cgi.FieldStorage`.
-        """
-        files = MultiDict()
-        for name, item in self.POST.iterallitems():
-            if hasattr(item, 'filename'):
-                files[name] = item
-        return files
-
-    @DictProperty('environ', 'bottle.params', read_only=True)
-    def params(self):
-        """ A combined :class:`MultiDict` with values from :attr:`forms` and
-            :attr:`GET`. File-uploads are not included. """
-        params = MultiDict(self.GET)
-        for key, value in self.forms.iterallitems():
-            params[key] = value
-        return params
-
-    @DictProperty('environ', 'bottle.body', read_only=True)
-    def _body(self):
-        """ The HTTP request body as a seekable file-like object.
-
-            This property returns a copy of the `wsgi.input` stream and should
-            be used instead of `environ['wsgi.input']`.
-         """
-        maxread = max(0, self.content_length)
-        stream = self.environ['wsgi.input']
-        body = BytesIO() if maxread < MEMFILE_MAX else TemporaryFile(mode='w+b')
-        while maxread > 0:
-            part = stream.read(min(maxread, MEMFILE_MAX))
-            if not part: break
-            body.write(part)
-            maxread -= len(part)
-        self.environ['wsgi.input'] = body
-        body.seek(0)
-        return body
-
     @property
-    def body(self):
-        self._body.seek(0)
-        return self._body
-
-    @property
-    def auth(self): #TODO: Tests and docs. Add support for digest. namedtuple?
-        """ HTTP authorization data as a (user, passwd) tuple. (experimental)
-
-            This implementation currently only supports basic auth and returns
-            None on errors.
-        """
-        return parse_auth(self.headers.get('Authorization',''))
-
-    @DictProperty('environ', 'bottle.cookies', read_only=True)
     def COOKIES(self):
-        """ Cookies parsed into a dictionary. Signed cookies are NOT decoded
-            automatically. See :meth:`get_cookie` for details.
-        """
-        raw_dict = SimpleCookie(self.headers.get('Cookie',''))
-        cookies = {}
-        for cookie in raw_dict.itervalues():
-            cookies[cookie.key] = cookie.value
-        return cookies
+        ''' Alias for :attr:`cookies` (deprecated). '''
+        depr('BaseRequest.COOKIES was renamed to BaseRequest.cookies (lowercase).')
+        return self.cookies
 
-    def get_cookie(self, key, secret=None):
-        """ Return the content of a cookie. To read a `Signed Cookies`, use the
-            same `secret` as used to create the cookie (see
-            :meth:`Response.set_cookie`). If anything goes wrong, None is
-            returned.
-        """
-        value = self.COOKIES.get(key)
-        if secret and value:
-            dec = cookie_decode(value, secret) # (key, value) tuple or None
-            return dec[1] if dec and dec[0] == key else None
-        return value or None
+    @property
+    def url(self):
+        """ The full request URI including hostname and scheme. If your app
+            lives behind a reverse proxy or load balancer and you get confusing
+            results, make sure that the ``X-Forwarded-Host`` header is set
+            correctly. """
+        return self.urlparts.geturl()
+
+    @DictProperty('environ', 'bottle.request.urlparts', read_only=True)
+    def urlparts(self):
+        ''' The :attr:`url` string as an :class:`urlparse.SplitResult` tuple.
+            The tuple contains (scheme, host, path, query_string and fragment),
+            but the fragment is always empty because it is not visible to the
+            server. '''
+        env = self.environ
+        http = env.get('wsgi.url_scheme', 'http')
+        host = env.get('HTTP_X_FORWARDED_HOST') or env.get('HTTP_HOST')
+        if not host:
+            # HTTP 1.1 requires a Host-header. This is for HTTP/1.0 clients.
+            host = env.get('SERVER_NAME', '127.0.0.1')
+            port = env.get('SERVER_PORT')
+            if port and port != ('80' if http == 'http' else '443'):
+                host += ':' + port
+        path = urlquote(self.fullpath)
+        return UrlSplitResult(http, host, path, env.get('QUERY_STRING'), '')
+
+    @property
+    def fullpath(self):
+        """ Request path including :attr:`script_name` (if present). """
+        return urljoin(self.script_name, self.path.lstrip('/'))
+
+    @property
+    def query_string(self):
+        """ The raw :attr:`query` part of the URL (everything in between ``?``
+            and ``#``) as a string. """
+        return self.environ.get('QUERY_STRING', '')
+
+    @property
+    def script_name(self):
+        ''' The initial portion of the URL's `path` that was removed by a higher
+            level (server or routing middleware) before the application was
+            called. This property returns an empty string, or a path with
+            leading and tailing slashes. '''
+        script_name = self.environ.get('SCRIPT_NAME', '').strip('/')
+        return '/' + script_name + '/' if script_name else '/'
+
+    def path_shift(self, shift=1):
+        ''' Shift path segments from :attr:`path` to :attr:`script_name` and
+            vice versa.
+
+           :param shift: The number of path segments to shift. May be negative
+                         to change the shift direction. (default: 1)
+        '''
+        script = self.environ.get('SCRIPT_NAME','/')
+        self['SCRIPT_NAME'], self['PATH_INFO'] = path_shift(script, self.path, shift)
+
+    @property
+    def content_length(self):
+        ''' The request body length as an integer. The client is responsible to
+            set this header. Otherwise, the real length of the body is unknown
+            and -1 is returned. In this case, :attr:`body` will be empty. '''
+        return int(self.environ.get('CONTENT_LENGTH') or -1)
+
+    @property
+    def is_xhr(self):
+        ''' True if the request was triggered by a XMLHttpRequest. This only
+            works with JavaScript libraries that support the `X-Requested-With`
+            header (most of the popular libraries do). '''
+        requested_with = self.environ.get('HTTP_X_REQUESTED_WITH','')
+        return requested_with.lower() == 'xmlhttprequest'
 
     @property
     def is_ajax(self):
-        ''' True if the request was generated using XMLHttpRequest '''
-        #TODO: write tests
-        return self.headers.get('X-Requested-With') == 'XMLHttpRequest'
-
-
-class Response(threading.local):
-    """ Represents a single HTTP response using thread-local attributes.
-    """
-
-    def __init__(self):
-        self.bind()
-
-    def bind(self):
-        """ Resets the Response object to its factory defaults. """
-        self._COOKIES = None
-        self.status = 200
-        self.headers = HeaderDict()
-        self.content_type = 'text/html; charset=UTF-8'
+        ''' Alias for :attr:`is_xhr`. "Ajax" is not the right term. '''
+        return self.is_xhr
 
     @property
-    def header(self):
-        depr("Response.header renamed to Response.headers")
-        return self.headers
+    def auth(self):
+        """ HTTP authentication data as a (user, password) tuple. This
+            implementation currently supports basic (not digest) authentication
+            only. If the authentication happened at a higher level (e.g. in the
+            front web-server or a middleware), the password field is None, but
+            the user field is looked up from the ``REMOTE_USER`` environ
+            variable. On any errors, None is returned. """
+        basic = parse_auth(self.environ.get('HTTP_AUTHORIZATION',''))
+        if basic: return basic
+        ruser = self.environ.get('REMOTE_USER')
+        if ruser: return (ruser, None)
+        return None
+
+    @property
+    def remote_route(self):
+        """ A list of all IPs that were involved in this request, starting with
+            the client IP and followed by zero or more proxies. This does only
+            work if all proxies support the ```X-Forwarded-For`` header. Note
+            that this information can be forged by malicious clients. """
+        proxy = self.environ.get('HTTP_X_FORWARDED_FOR')
+        if proxy: return [ip.strip() for ip in proxy.split(',')]
+        remote = self.environ.get('REMOTE_ADDR')
+        return [remote] if remote else []
+
+    @property
+    def remote_addr(self):
+        """ The client IP as a string. Note that this information can be forged
+            by malicious clients. """
+        route = self.remote_route
+        return route[0] if route else None
+
+    def copy(self):
+        """ Return a new :class:`Request` with a shallow :attr:`environ` copy. """
+        return Request(self.environ.copy())
+
+    def __getitem__(self, key): return self.environ[key]
+    def __delitem__(self, key): self[key] = ""; del(self.environ[key])
+    def __iter__(self): return iter(self.environ)
+    def __len__(self): return len(self.environ)
+    def keys(self): return self.environ.keys()
+    def __setitem__(self, key, value):
+        """ Change an environ value and clear all caches that depend on it. """
+
+        if self.environ.get('bottle.request.readonly'):
+            raise KeyError('The environ dictionary is read-only.')
+
+        self.environ[key] = value
+        todelete = ()
+
+        if key == 'wsgi.input':
+            todelete = ('body', 'forms', 'files', 'params', 'post', 'json')
+        elif key == 'QUERY_STRING':
+            todelete = ('query', 'params')
+        elif key.startswith('HTTP_'):
+            todelete = ('headers', 'cookies')
+
+        for key in todelete:
+            self.environ.pop('bottle.request.'+key, None)
+
+    def __repr__(self):
+        return '<%s: %s %s>' % (self.__class__.__name__, self.method, self.url)
+
+def _hkey(s):
+    return s.title().replace('_','-')
+
+
+class HeaderProperty(object):
+    def __init__(self, name, reader=None, writer=str, default=''):
+        self.name, self.reader, self.writer, self.default = name, reader, writer, default
+        self.__doc__ = 'Current value of the %r header.' % name.title()
+
+    def __get__(self, obj, cls):
+        if obj is None: return self
+        value = obj.headers.get(self.name)
+        return self.reader(value) if (value and self.reader) else (value or self.default)
+
+    def __set__(self, obj, value):
+        if self.writer: value = self.writer(value)
+        obj.headers[self.name] = value
+
+    def __delete__(self, obj):
+        if self.name in obj.headers:
+            del obj.headers[self.name]
+
+
+class BaseResponse(object):
+    """ Storage class for a response body as well as headers and cookies.
+
+        This class does support dict-like case-insensitive item-access to
+        headers, but is NOT a dict. Most notably, iterating over a response
+        yields parts of the body and not the headers.
+    """
+
+    default_status = 200
+    default_content_type = 'text/html; charset=UTF-8'
+
+    # Header blacklist for specific response codes
+    # (rfc2616 section 10.2.3 and 10.3.5)
+    bad_headers = {
+        204: set(('Content-Type',)),
+        304: set(('Allow', 'Content-Encoding', 'Content-Language',
+                  'Content-Length', 'Content-Range', 'Content-Type',
+                  'Content-Md5', 'Last-Modified'))}
+
+    def __init__(self, body='', status=None, **headers):
+        #: The HTTP status code as an integer (e.g. 404).
+        #: Do not change the value manually, use :attr:`status` instead.
+        self.status_code = None
+        #: The HTTP status line as a string (e.g. "404 Not Found").
+        #: Do not change the value manually, use :attr:`status` instead.
+        self.status_line = None
+        #: The response body as one of the supported data types.
+        self.body = body
+        self._cookies = None
+        self._headers = {'Content-Type': [self.default_content_type]}
+        self.status = status or self.default_status
+        if headers:
+            for name, value in headers.items():
+                self[name] = value
 
     def copy(self):
         ''' Returns a copy of self. '''
         copy = Response()
         copy.status = self.status
-        copy.headers = self.headers.copy()
-        copy.content_type = self.content_type
+        copy._headers = dict((k, v[:]) for (k, v) in self._headers.items())
         return copy
 
+    def __iter__(self):
+        return iter(self.body)
+
+    def close(self):
+        if hasattr(self.body, 'close'):
+            self.body.close()
+
+    def _set_status(self, status):
+        if isinstance(status, int):
+            code, status = status, _HTTP_STATUS_LINES.get(status)
+        elif ' ' in status:
+            status = status.strip()
+            code   = int(status.split()[0])
+        else:
+            raise ValueError('String status line without a reason phrase.')
+        if not 100 <= code <= 999: raise ValueError('Status code out of range.')
+        self.status_code = code
+        self.status_line = status or ('%d Unknown' % code)
+
+    status = property(lambda self: self.status_code, _set_status, None,
+        ''' A writeable property to change the HTTP response status. It accepts
+            either a numeric code (100-999) or a string with a custom reason
+            phrase (e.g. "404 Brain not found"). Both :data:`status_line` and
+            :data:`status_code` are updates accordingly. The return value is
+            always a numeric code. ''')
+    del _set_status
+
+    @property
+    def headers(self):
+        ''' An instance of :class:`HeaderDict`, a case-insensitive dict-like
+            view on the response headers. '''
+        self.__dict__['headers'] = hdict = HeaderDict()
+        hdict.dict = self._headers
+        return hdict
+
+    def __contains__(self, name): return _hkey(name) in self._headers
+    def __delitem__(self, name):  del self._headers[_hkey(name)]
+    def __getitem__(self, name):  return self._headers[_hkey(name)][-1]
+    def __setitem__(self, name, value): self._headers[_hkey(name)] = [str(value)]
+
+    def get_header(self, name, default=None):
+        ''' Return the value of a previously defined header. If there is no
+            header with that name, return a default value. '''
+        return self._headers.get(_hkey(name), [default])[-1]
+
+    def set_header(self, name, value, append=False):
+        ''' Create a new response header, replacing any previously defined
+            headers with the same name. '''
+        if append:
+            self.add_header(name, value)
+        else:
+            self._headers[_hkey(name)] = [str(value)]
+
+    def add_header(self, name, value):
+        ''' Add an additional response header, not removing duplicates. '''
+        self._headers.setdefault(_hkey(name), []).append(str(value))
+
+    def iter_headers(self):
+        ''' Yield (header, value) tuples, skipping headers that are not
+            allowed with the current response status code. '''
+        headers = self._headers.iteritems()
+        bad_headers = self.bad_headers.get(self.status_code)
+        if bad_headers:
+            headers = (h for h in headers if h[0] not in bad_headers)
+        for name, values in headers:
+            for value in values:
+                yield name, value
+        if self._cookies:
+            for c in self._cookies.values():
+                yield 'Set-Cookie', c.OutputString()
+
     def wsgiheader(self):
-        ''' Returns a wsgi conform list of header/value pairs. '''
-        for c in self.COOKIES.values():
-            if c.OutputString() not in self.headers.getall('Set-Cookie'):
-                self.headers.append('Set-Cookie', c.OutputString())
-        # rfc2616 section 10.2.3, 10.3.5
-        if self.status in (204, 304) and 'content-type' in self.headers:
-            del self.headers['content-type']
-        if self.status == 304:
-            for h in ('allow', 'content-encoding', 'content-language',
-                      'content-length', 'content-md5', 'content-range',
-                      'content-type', 'last-modified'): # + c-location, expires?
-                if h in self.headers:
-                     del self.headers[h]
-        return list(self.headers.iterallitems())
-    headerlist = property(wsgiheader)
+        depr('The wsgiheader method is deprecated. See headerlist.') #0.10
+        return self.headerlist
+
+    @property
+    def headerlist(self):
+        ''' WSGI conform list of (header, value) tuples. '''
+        return list(self.iter_headers())
+
+    content_type = HeaderProperty('Content-Type')
+    content_length = HeaderProperty('Content-Length', reader=int)
 
     @property
     def charset(self):
-        """ Return the charset specified in the content-type header.
-
-            This defaults to `UTF-8`.
-        """
+        """ Return the charset specified in the content-type header (default: utf8). """
         if 'charset=' in self.content_type:
             return self.content_type.split('charset=')[-1].split(';')[0].strip()
         return 'UTF-8'
 
     @property
     def COOKIES(self):
-        """ A dict-like SimpleCookie instance. Use :meth:`set_cookie` instead. """
-        if not self._COOKIES:
-            self._COOKIES = SimpleCookie()
-        return self._COOKIES
+        """ A dict-like SimpleCookie instance. This should not be used directly.
+            See :meth:`set_cookie`. """
+        depr('The COOKIES dict is deprecated. Use `set_cookie()` instead.') # 0.10
+        if not self._cookies:
+            self._cookies = SimpleCookie()
+        return self._cookies
 
-    def set_cookie(self, key, value, secret=None, **kargs):
-        ''' Add a cookie or overwrite an old one. If the `secret` parameter is
+    def set_cookie(self, key, value, secret=None, **options):
+        ''' Create a new cookie or replace an old one. If the `secret` parameter is
             set, create a `Signed Cookie` (described below).
 
             :param key: the name of the cookie.
             :param value: the value of the cookie.
-            :param secret: required for signed cookies. (default: None)
+            :param secret: a signature key required for signed cookies.
+
+            Additionally, this method accepts all RFC 2109 attributes that are
+            supported by :class:`cookie.Morsel`, including:
+
             :param max_age: maximum age in seconds. (default: None)
-            :param expires: a datetime object or UNIX timestamp. (defaut: None)
+            :param expires: a datetime object or UNIX timestamp. (default: None)
             :param domain: the domain that is allowed to read the cookie.
               (default: current domain)
-            :param path: limits the cookie to a given path (default: /)
+            :param path: limits the cookie to a given path (default: ``/``)
+            :param secure: limit the cookie to HTTPS connections (default: off).
+            :param httponly: prevents client-side javascript to read this cookie
+              (default: off, requires Python 2.6 or newer).
 
-            If neither `expires` nor `max_age` are set (default), the cookie
-            lasts only as long as the browser is not closed.
+            If neither `expires` nor `max_age` is set (default), the cookie will
+            expire at the end of the browser session (as soon as the browser
+            window is closed).
 
             Signed cookies may store any pickle-able object and are
             cryptographically signed to prevent manipulation. Keep in mind that
@@ -1093,31 +1319,45 @@ class Response(threading.local):
             cookie). The main intention is to make pickling and unpickling
             save, not to store secret information at client side.
         '''
+        if not self._cookies:
+            self._cookies = SimpleCookie()
+
         if secret:
             value = touni(cookie_encode((key, value), secret))
         elif not isinstance(value, basestring):
-            raise TypeError('Secret missing for non-string Cookie.')
+            raise TypeError('Secret key missing for non-string Cookie.')
 
-        self.COOKIES[key] = value
-        for k, v in kargs.iteritems():
-            self.COOKIES[key][k.replace('_', '-')] = v
+        if len(value) > 4096: raise ValueError('Cookie value to long.')
+        self._cookies[key] = value
+        for k, v in options.iteritems():
+            self._cookies[key][k.replace('_', '-')] = v
 
     def delete_cookie(self, key, **kwargs):
         ''' Delete a cookie. Be sure to use the same `domain` and `path`
-            parameters as used to create the cookie. '''
+            settings as used to create the cookie. '''
         kwargs['max_age'] = -1
         kwargs['expires'] = 0
         self.set_cookie(key, '', **kwargs)
 
-    def get_content_type(self):
-        """ Current 'Content-Type' header. """
-        return self.headers['Content-Type']
+    def __repr__(self):
+        out = ''
+        for name, value in self.headerlist:
+            out += '%s: %s\n' % (name.title(), value.strip())
+        return out
 
-    def set_content_type(self, value):
-        self.headers['Content-Type'] = value
 
-    content_type = property(get_content_type, set_content_type, None,
-                            get_content_type.__doc__)
+class LocalRequest(BaseRequest, threading.local):
+    ''' A thread-local subclass of :class:`BaseRequest`. '''
+    def __init__(self): pass
+    bind = BaseRequest.__init__
+
+
+class LocalResponse(BaseResponse, threading.local):
+    ''' A thread-local subclass of :class:`BaseResponse`. '''
+    bind = BaseResponse.__init__
+
+Response = LocalResponse # BC 0.9
+Request  = LocalRequest  # BC 0.9
 
 
 
@@ -1128,10 +1368,11 @@ class Response(threading.local):
 # Plugins ######################################################################
 ###############################################################################
 
-
+class PluginError(BottleException): pass
 
 class JSONPlugin(object):
     name = 'json'
+    api  = 2
 
     def __init__(self, json_dumps=json_dumps):
         self.json_dumps = json_dumps
@@ -1142,18 +1383,23 @@ class JSONPlugin(object):
         def wrapper(*a, **ka):
             rv = callback(*a, **ka)
             if isinstance(rv, dict):
+                #Attempt to serialize, raises exception on failure
+                json_response = dumps(rv)
+                #Set content type only if serialization succesful
                 response.content_type = 'application/json'
-                return dumps(rv)
+                return json_response
             return rv
         return wrapper
 
 
-
 class HooksPlugin(object):
     name = 'hooks'
+    api  = 2
+
+    _names = 'before_request', 'after_request', 'app_reset'
 
     def __init__(self):
-        self.hooks = {'before_request': [], 'after_request': []}
+        self.hooks = dict((name, []) for name in self._names)
         self.app = None
 
     def _empty(self):
@@ -1164,56 +1410,29 @@ class HooksPlugin(object):
 
     def add(self, name, func):
         ''' Attach a callback to a hook. '''
-        if name not in self.hooks:
-            raise ValueError("Unknown hook name %s" % name)
         was_empty = self._empty()
-        self.hooks[name].append(func)
+        self.hooks.setdefault(name, []).append(func)
         if self.app and was_empty and not self._empty(): self.app.reset()
 
     def remove(self, name, func):
         ''' Remove a callback from a hook. '''
-        if name not in self.hooks:
-            raise ValueError("Unknown hook name %s" % name)
         was_empty = self._empty()
-        self.hooks[name].remove(func)
+        if name in self.hooks and func in self.hooks[name]:
+            self.hooks[name].remove(func)
         if self.app and not was_empty and self._empty(): self.app.reset()
 
+    def trigger(self, name, *a, **ka):
+        ''' Trigger a hook and return a list of results. '''
+        hooks = self.hooks[name]
+        if ka.pop('reversed', False): hooks = hooks[::-1]
+        return [hook(*a, **ka) for hook in hooks]
+    
     def apply(self, callback, context):
         if self._empty(): return callback
-        before_request = self.hooks['before_request']
-        after_request  = self.hooks['after_request']
         def wrapper(*a, **ka):
-            for hook in before_request: hook()
+            self.trigger('before_request')
             rv = callback(*a, **ka)
-            for hook in after_request[::-1]: hook()
-            return rv
-        return wrapper
-
-
-
-class TypeFilterPlugin(object):
-    def __init__(self):
-        self.filter = []
-        self.app = None
-
-    def setup(self, app):
-        self.app = app
-
-    def add(self, ftype, func):
-        if not isinstance(ftype, type):
-            raise TypeError("Expected type object, got %s" % type(ftype))
-        self.filter = [(t, f) for (t, f) in self.filter if t != ftype]
-        self.filter.append((ftype, func))
-        if len(self.filter) == 1 and self.app: self.app.reset()
-
-    def apply(self, callback, context):
-        filter = self.filter
-        if not filter: return callback
-        def wrapper(*a, **ka):
-            rv = callback(*a, **ka)
-            for testtype, filterfunc in filter:
-                if isinstance(rv, testtype):
-                    rv = filterfunc(rv)
+            self.trigger('after_request', reversed=True)
             return rv
         return wrapper
 
@@ -1224,14 +1443,15 @@ class TemplatePlugin(object):
         element must be a dict with additional options (e.g. `template_engine`)
         or default variables for the template. '''
     name = 'template'
+    api  = 2
 
-    def apply(self, callback, context):
-        conf = context['config'].get('template')
+    def apply(self, callback, route):
+        conf = route.config.get('template')
         if isinstance(conf, (tuple, list)) and len(conf) == 2:
             return view(conf[0], **conf[1])(callback)
-        elif isinstance(conf, str) and 'template_opts' in context['config']:
+        elif isinstance(conf, str) and 'template_opts' in route.config:
             depr('The `template_opts` parameter is deprecated.') #0.9
-            return view(conf, **context['config']['template_opts'])(callback)
+            return view(conf, **route.config['template_opts'])(callback)
         elif isinstance(conf, str):
             return view(conf)(callback)
         else:
@@ -1276,53 +1496,95 @@ class _ImportRedirect(object):
 
 
 class MultiDict(DictMixin):
-    """ A dict that remembers old values for each key """
-    # collections.MutableMapping would be better for Python >= 2.6
-    def __init__(self, *a, **k):
-        self.dict = dict()
-        for k, v in dict(*a, **k).iteritems():
-            self[k] = v
+    """ This dict stores multiple values per key, but behaves exactly like a
+        normal dict in that it returns only the newest value for any given key.
+        There are special methods available to access the full list of values.
+    """
 
+    def __init__(self, *a, **k):
+        self.dict = dict((k, [v]) for k, v in dict(*a, **k).iteritems())
     def __len__(self): return len(self.dict)
     def __iter__(self): return iter(self.dict)
     def __contains__(self, key): return key in self.dict
     def __delitem__(self, key): del self.dict[key]
-    def keys(self): return self.dict.keys()
-    def __getitem__(self, key): return self.get(key, KeyError, -1)
+    def __getitem__(self, key): return self.dict[key][-1]
     def __setitem__(self, key, value): self.append(key, value)
-
-    def append(self, key, value): self.dict.setdefault(key, []).append(value)
-    def replace(self, key, value): self.dict[key] = [value]
-    def getall(self, key): return self.dict.get(key) or []
-
-    def get(self, key, default=None, index=-1):
-        if key not in self.dict and default != KeyError:
-            return [default][index]
-        return self.dict[key][index]
-
+    def iterkeys(self): return self.dict.iterkeys()
+    def itervalues(self): return (v[-1] for v in self.dict.itervalues())
+    def iteritems(self): return ((k, v[-1]) for (k, v) in self.dict.iteritems())
     def iterallitems(self):
         for key, values in self.dict.iteritems():
             for value in values:
                 yield key, value
 
+    # 2to3 is not able to fix these automatically.
+    keys     = iterkeys     if py3k else lambda self: list(self.iterkeys())
+    values   = itervalues   if py3k else lambda self: list(self.itervalues())
+    items    = iteritems    if py3k else lambda self: list(self.iteritems())
+    allitems = iterallitems if py3k else lambda self: list(self.iterallitems())
+
+    def get(self, key, default=None, index=-1, type=None):
+        ''' Return the most recent value for a key.
+
+            :param default: The default value to be returned if the key is not
+                   present or the type conversion fails.
+            :param index: An index for the list of available values.
+            :param type: If defined, this callable is used to cast the value
+                    into a specific type. Exception are suppressed and result in
+                    the default value to be returned.
+        '''
+        try:
+            val = self.dict[key][index]
+            return type(val) if type else val
+        except Exception, e:
+            pass
+        return default
+
+    #: Alias for :meth:`get` to mimic other multi-dict APIs (Django)
+    getone = get
+
+    def append(self, key, value):
+        ''' Add a new value to the list of values for this key. '''
+        self.dict.setdefault(key, []).append(value)
+
+    def replace(self, key, value):
+        ''' Replace the list of values with a single value. '''
+        self.dict[key] = [value]
+
+    def getall(self, key):
+        ''' Return a (possibly empty) list of values for a key. '''
+        return self.dict.get(key) or []
+
+
+class FormsDict(MultiDict):
+    ''' A :class:`MultiDict` with attribute-like access to form values.
+        Missing attributes are always `None`. '''
+    def __getattr__(self, name):
+        return self.get(name, None)
+
 
 class HeaderDict(MultiDict):
-    """ Same as :class:`MultiDict`, but title()s the keys and overwrites. """
-    def __contains__(self, key):
-        return MultiDict.__contains__(self, self.httpkey(key))
-    def __getitem__(self, key):
-        return MultiDict.__getitem__(self, self.httpkey(key))
-    def __delitem__(self, key):
-        return MultiDict.__delitem__(self, self.httpkey(key))
-    def __setitem__(self, key, value): self.replace(key, value)
-    def get(self, key, default=None, index=-1):
-        return MultiDict.get(self, self.httpkey(key), default, index)
+    """ A case-insensitive version of :class:`MultiDict` that defaults to
+        replace the old value instead of appending it. """
+
+    def __init__(self, *a, **ka):
+        self.dict = {}
+        if a or ka: self.update(*a, **ka)
+
+    def __contains__(self, key): return _hkey(key) in self.dict
+    def __delitem__(self, key): del self.dict[_hkey(key)]
+    def __getitem__(self, key): return self.dict[_hkey(key)][-1]
+    def __setitem__(self, key, value): self.dict[_hkey(key)] = [str(value)]
     def append(self, key, value):
-        return MultiDict.append(self, self.httpkey(key), str(value))
-    def replace(self, key, value):
-        return MultiDict.replace(self, self.httpkey(key), str(value))
-    def getall(self, key): return MultiDict.getall(self, self.httpkey(key))
-    def httpkey(self, key): return str(key).replace('_','-').title()
+        self.dict.setdefault(_hkey(key), []).append(str(value))
+    def replace(self, key, value): self.dict[_hkey(key)] = [str(value)]
+    def getall(self, key): return self.dict.get(_hkey(key)) or []
+    def get(self, key, default=None, index=-1):
+        return MultiDict.get(self, _hkey(key), default, index)
+    def filter(self, names):
+        for name in map(_hkey, names):
+            if name in self.dict:
+                del self.dict[name]
 
 
 class WSGIHeaderDict(DictMixin):
@@ -1369,9 +1631,42 @@ class WSGIHeaderDict(DictMixin):
             elif key in self.cgikeys:
                 yield key.replace('_', '-').title()
 
-    def keys(self): return list(self)
-    def __len__(self): return len(list(self))
+    def keys(self): return [x for x in self]
+    def __len__(self): return len(self.keys())
     def __contains__(self, key): return self._ekey(key) in self.environ
+
+
+class ConfigDict(dict):
+    ''' A dict-subclass with some extras: You can access keys like attributes.
+        Uppercase attributes create new ConfigDicts and act as name-spaces.
+        Other missing attributes return None. Calling a ConfigDict updates its
+        values and returns itself.
+
+        >>> cfg = ConfigDict()
+        >>> cfg.Namespace.value = 5
+        >>> cfg.OtherNamespace(a=1, b=2)
+        >>> cfg
+        {'Namespace': {'value': 5}, 'OtherNamespace': {'a': 1, 'b': 2}}
+    '''
+
+    def __getattr__(self, key):
+        if key in self: return self[key]
+        if key[0].isupper(): return self.setdefault(key, ConfigDict())
+        return
+
+    def __setattr__(self, key, value):
+        if hasattr(dict, key):
+            raise AttributeError('Read-only attribute.')
+        if key in self and self[key] and isinstance(self[key], ConfigDict):
+            raise AttributeError('Non-empty namespace attribute.')
+        self[key] = value
+
+    def __delattr__(self, key):
+        if key in self: del self[key]
+
+    def __call__(self, *a, **ka):
+        for key, value in dict(*a, **ka).iteritems(): setattr(self, key, value)
+        return self
 
 
 class AppStack(list):
@@ -1413,30 +1708,21 @@ class WSGIFileWrapper(object):
 ###############################################################################
 
 
-def dict2json(d):
-    depr('JSONPlugin is the preferred way to return JSON.') #0.9
-    response.content_type = 'application/json'
-    return json_dumps(d)
-
-
 def abort(code=500, text='Unknown Error: Application stopped.'):
     """ Aborts execution and causes a HTTP error. """
     raise HTTPError(code, text)
 
 
-def redirect(url, code=303):
-    """ Aborts execution and causes a 303 redirect. """
+def redirect(url, code=None):
+    """ Aborts execution and causes a 303 or 302 redirect, depending on
+        the HTTP protocol version. """
+    if code is None:
+        code = 303 if request.get('SERVER_PROTOCOL') == "HTTP/1.1" else 302
     location = urljoin(request.url, url)
     raise HTTPResponse("", status=code, header=dict(Location=location))
 
 
-def send_file(*a, **k): #BC 0.6.4
-    """ Raises the output of static_file(). (deprecated) """
-    depr("Use 'raise static_file()' instead of 'send_file()'.")
-    raise static_file(*a, **k)
-
-
-def static_file(filename, root, mimetype='auto', guessmime=True, download=False):
+def static_file(filename, root, mimetype='auto', download=False):
     """ Open a file in a safe way and return :exc:`HTTPResponse` with status
         code 200, 305, 401 or 404. Set Content-Type, Content-Encoding,
         Content-Length and Last-Modified header. Obey If-Modified-Since header
@@ -1453,9 +1739,6 @@ def static_file(filename, root, mimetype='auto', guessmime=True, download=False)
     if not os.access(filename, os.R_OK):
         return HTTPError(403, "You do not have permission to access this file.")
 
-    if not guessmime: #0.9
-       if mimetype == 'auto': mimetype = 'text/plain'
-       depr("To disable mime-type guessing, specify a type explicitly.")
     if mimetype == 'auto':
         mimetype, encoding = mimetypes.guess_type(filename)
         if mimetype: header['Content-Type'] = mimetype
@@ -1513,9 +1796,10 @@ def parse_auth(header):
     try:
         method, data = header.split(None, 1)
         if method.lower() == 'basic':
-            name, pwd = base64.b64decode(data).split(':', 1)
-            return name, pwd
-    except (KeyError, ValueError, TypeError):
+            #TODO: Add 2to3 save base64[encode/decode] functions.
+            user, pwd = touni(base64.b64decode(tob(data))).split(':',1)
+            return user, pwd
+    except (KeyError, ValueError):
         return None
 
 
@@ -1545,6 +1829,18 @@ def cookie_decode(data, key):
 def cookie_is_encoded(data):
     ''' Return True if the argument looks like a encoded cookie.'''
     return bool(data.startswith(tob('!')) and tob('?') in data)
+
+
+def html_escape(string):
+    ''' Escape HTML special characters ``&<>`` and quotes ``'"``. '''
+    return string.replace('&','&amp;').replace('<','&lt;').replace('>','&gt;')\
+                 .replace('"','&quot;').replace("'",'&#039;')
+
+
+def html_quote(string):
+    ''' Escape and quote a string to be used as an HTTP attribute.'''
+    return '"%s"' % html_escape(string).replace('\n','%#10;')\
+                    .replace('\r','&#13;').replace('\t','&#9;')
 
 
 def yieldroutes(func):
@@ -1599,10 +1895,6 @@ def path_shift(script_name, path_info, shift=1):
     return new_script_name, new_path_info
 
 
-
-# Decorators
-#TODO: Replace default_app() with app()
-
 def validate(**vkargs):
     """
     Validates and manipulates keyword arguments by user defined callables.
@@ -1651,11 +1943,6 @@ url = make_default_app_wrapper('get_url')
 del name
 
 
-def default():
-    depr("The default() decorator is deprecated. Use @error(404) instead.")
-    return error(404)
-
-
 
 
 
@@ -1693,9 +1980,8 @@ class CGIServer(ServerAdapter):
 class FlupFCGIServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         import flup.server.fcgi
-        kwargs = {'bindAddress':(self.host, self.port)}
-        kwargs.update(self.options) # allow to override bindAddress and others
-        flup.server.fcgi.WSGIServer(handler, **kwargs).run()
+        self.options.setdefault('bindAddress', (self.host, self.port))
+        flup.server.fcgi.WSGIServer(handler, **self.options).run()
 
 
 class WSGIRefServer(ServerAdapter):
@@ -1718,6 +2004,7 @@ class CherryPyServer(ServerAdapter):
         finally:
             server.stop()
 
+
 class PasteServer(ServerAdapter):
     def run(self, handler): # pragma: no cover
         from paste import httpserver
@@ -1726,6 +2013,7 @@ class PasteServer(ServerAdapter):
             handler = TransLogger(handler)
         httpserver.serve(handler, host=self.host, port=str(self.port),
                          **self.options)
+
 
 class MeinheldServer(ServerAdapter):
     def run(self, handler):
@@ -1811,22 +2099,28 @@ class GeventServer(ServerAdapter):
           issues: No streaming, no pipelining, no SSL.
     """
     def run(self, handler):
-        from gevent import wsgi as wsgi_fast, pywsgi as wsgi, monkey
+        from gevent import wsgi as wsgi_fast, pywsgi, monkey, local
         if self.options.get('monkey', True):
-            monkey.patch_all()
-        if self.options.get('fast', False):
-            wsgi = wsgi_fast
+            if not threading.local is local.local: monkey.patch_all()
+        wsgi = wsgi_fast if self.options.get('fast') else pywsgi
         wsgi.WSGIServer((self.host, self.port), handler).serve_forever()
 
 
 class GunicornServer(ServerAdapter):
     """ Untested. """
     def run(self, handler):
-        from gunicorn.arbiter import Arbiter
-        from gunicorn.config import Config
-        handler.cfg = Config({'bind': "%s:%d" % (self.host, self.port), 'workers': 4})
-        arbiter = Arbiter(handler)
-        arbiter.run()
+        from gunicorn.app.base import Application
+
+        config = {'bind': "%s:%d" % (self.host, int(self.port)), 'workers': 4}
+
+        class GunicornApplication(Application):
+            def init(self, parser, opts, args):
+                return config
+
+            def load(self):
+                return handler
+
+        GunicornApplication().run()
 
 
 class EventletServer(ServerAdapter):
@@ -1837,8 +2131,7 @@ class EventletServer(ServerAdapter):
 
 
 class RocketServer(ServerAdapter):
-    """ Untested. As requested in issue 63
-        https://github.com/defnull/bottle/issues/#issue/63 """
+    """ Untested. """
     def run(self, handler):
         from rocket import Rocket
         server = Rocket((self.host, self.port), 'wsgi', { 'wsgi_app' : handler })
@@ -1846,7 +2139,7 @@ class RocketServer(ServerAdapter):
 
 
 class BjoernServer(ServerAdapter):
-    """ Screamingly fast server written in C: https://github.com/jonashaag/bjoern """
+    """ Fast server written in C: https://github.com/jonashaag/bjoern """
     def run(self, handler):
         from bjoern import run
         run(handler, self.host, self.port)
@@ -1861,7 +2154,6 @@ class AutoServer(ServerAdapter):
                 return sa(self.host, self.port, **self.options).run(handler)
             except ImportError:
                 pass
-
 
 server_names = {
     'cgi': CGIServer,
@@ -1893,51 +2185,32 @@ server_names = {
 ###############################################################################
 
 
-def _load(target, **vars):
-    """ Fetch something from a module. The exact behaviour depends on the the
-        target string:
+def load(target, **namespace):
+    """ Import a module or fetch an object from a module.
 
-        If the target is a valid python import path (e.g. `package.module`),
-        the rightmost part is returned as a module object.
-        If the target contains a colon (e.g. `package.module:var`) the module
-        variable specified after the colon is returned.
-        If the part after the colon contains any non-alphanumeric characters
-        (e.g. `package.module:func(var)`) the result of the expression
-        is returned. The expression has access to keyword arguments supplied
-        to this function.
+        * ``package.module`` returns `module` as a module object.
+        * ``pack.mod:name`` returns the module variable `name` from `pack.mod`.
+        * ``pack.mod:func()`` calls `pack.mod.func()` and returns the result.
 
-        Example::
-        >>> _load('bottle')
-        <module 'bottle' from 'bottle.py'>
-        >>> _load('bottle:Bottle')
-        <class 'bottle.Bottle'>
-        >>> _load('bottle:cookie_encode(v, secret)', v='foo', secret='bar')
-        '!F+hN4dQxaDJ4QxxaZ+Z3jw==?gAJVA2Zvb3EBLg=='
-
+        The last form accepts not only function calls, but any type of
+        expression. Keyword arguments passed to this function are available as
+        local variables. Example: ``import_string('re:compile(x)', x='[a-z]')``
     """
     module, target = target.split(":", 1) if ':' in target else (target, None)
-    if module not in sys.modules:
-        __import__(module)
-    if not target:
-        return sys.modules[module]
-    if target.isalnum():
-        return getattr(sys.modules[module], target)
+    if module not in sys.modules: __import__(module)
+    if not target: return sys.modules[module]
+    if target.isalnum(): return getattr(sys.modules[module], target)
     package_name = module.split('.')[0]
-    vars[package_name] = sys.modules[package_name]
-    return eval('%s.%s' % (module, target), vars)
+    namespace[package_name] = sys.modules[package_name]
+    return eval('%s.%s' % (module, target), namespace)
 
 
 def load_app(target):
-    """ Load a bottle application based on a target string and return the
-        application object.
-
-        If the target is an import path (e.g. package.module), the application
-        stack is used to isolate the routes defined in that module.
-        If the target contains a colon (e.g. package.module:myapp) the
-        module variable specified after the colon is returned instead.
-    """
+    """ Load a bottle application from a module and make sure that the import
+        does not affect the current default application, but returns a separate
+        application object. See :func:`load` for the target parameter. """
     tmp = app.push() # Create a new "default application"
-    rv = _load(target) # Import the target module
+    rv = load(target) # Import the target module
     app.remove(tmp) # Remove the temporary added default application
     return rv if isinstance(rv, Bottle) else tmp
 
@@ -2085,7 +2358,7 @@ class TemplateError(HTTPError):
 
 class BaseTemplate(object):
     """ Base class and minimal API for template adapters """
-    extentions = ['tpl','html','thtml','stpl']
+    extensions = ['tpl','html','thtml','stpl']
     settings = {} #used in prepare()
     defaults = {} #used in render()
 
@@ -2124,7 +2397,7 @@ class BaseTemplate(object):
             fname = os.path.join(spath, name)
             if os.path.isfile(fname):
                 return fname
-            for ext in cls.extentions:
+            for ext in cls.extensions:
                 if os.path.isfile('%s.%s' % (fname, ext)):
                     return '%s.%s' % (fname, ext)
 
@@ -2132,6 +2405,7 @@ class BaseTemplate(object):
     def global_config(cls, key, *args):
         ''' This reads or sets the global settings stored in class.settings. '''
         if args:
+            cls.settings = cls.settings.copy() # Make settings local to class
             cls.settings[key] = args[0]
         else:
             return cls.settings[key]
@@ -2189,7 +2463,7 @@ class CheetahTemplate(BaseTemplate):
         self.context.vars.update(kwargs)
         out = str(self.tpl)
         self.context.vars.clear()
-        return [out]
+        return out
 
 
 class Jinja2Template(BaseTemplate):
@@ -2210,7 +2484,7 @@ class Jinja2Template(BaseTemplate):
         for dictarg in args: kwargs.update(dictarg)
         _defaults = self.defaults.copy()
         _defaults.update(kwargs)
-        return self.tpl.render(**_defaults).encode("utf-8")
+        return self.tpl.render(**_defaults)
 
     def loader(self, name):
         fname = self.search(name, self.lookup)
@@ -2246,7 +2520,8 @@ class SimpleTALTemplate(BaseTemplate):
 
 
 class SimpleTemplate(BaseTemplate):
-    blocks = ('if','elif','else','try','except','finally','for','while','with','def','class')
+    blocks = ('if', 'elif', 'else', 'try', 'except', 'finally', 'for', 'while',
+              'with', 'def', 'class')
     dedent_blocks = ('elif', 'else', 'except', 'finally')
 
     @lazy_attribute
@@ -2262,7 +2537,7 @@ class SimpleTemplate(BaseTemplate):
              |\#.*                        # Comments
             )''', re.VERBOSE)
 
-    def prepare(self, escape_func=cgi.escape, noescape=False):
+    def prepare(self, escape_func=html_escape, noescape=False, **kwargs):
         self.cache = {}
         enc = self.encoding
         self._str = lambda x: touni(x, enc)
@@ -2331,7 +2606,7 @@ class SimpleTemplate(BaseTemplate):
                 line = line.split('%',1)[1].lstrip() # Full line following the %
                 cline = self.split_comment(line).strip()
                 cmd = re.split(r'[^a-zA-Z0-9_]', cline)[0]
-                flush() ##encodig (TODO: why?)
+                flush() # You are actually reading this? Good luck, it's a mess :)
                 if cmd in self.blocks or multiline:
                     cmd = multiline or cmd
                     dedent = cmd in self.dedent_blocks # "else:"
@@ -2383,10 +2658,9 @@ class SimpleTemplate(BaseTemplate):
         eval(self.co, env)
         if '_rebase' in env:
             subtpl, rargs = env['_rebase']
-            subtpl = self.__class__(name=subtpl, lookup=self.lookup)
             rargs['_base'] = _stdout[:] #copy stdout
             del _stdout[:] # clear stdout
-            return subtpl.execute(_stdout, rargs)
+            return self.subtemplate(subtpl,_stdout,rargs)
         return env
 
     def render(self, *args, **kwargs):
@@ -2467,11 +2741,11 @@ simpletal_view = functools.partial(view, template_adapter=SimpleTALTemplate)
 TEMPLATE_PATH = ['./', './views/']
 TEMPLATES = {}
 DEBUG = False
-MEMFILE_MAX = 1024*100
 
 #: A dict to map HTTP status codes (e.g. 404) to phrases (e.g. 'Not Found')
 HTTP_CODES = httplib.responses
 HTTP_CODES[418] = "I'm a teapot" # RFC 2324
+_HTTP_STATUS_LINES = dict((k, '%d %s'%(k,v)) for (k,v) in HTTP_CODES.iteritems())
 
 #: The default template used for error pages. Override with @error()
 ERROR_PAGE_TEMPLATE = """
@@ -2484,13 +2758,15 @@ ERROR_PAGE_TEMPLATE = """
             <title>Error {{e.status}}: {{status_name}}</title>
             <style type="text/css">
               html {background-color: #eee; font-family: sans;}
-              body {background-color: #fff; border: 1px solid #ddd; padding: 15px; margin: 15px;}
+              body {background-color: #fff; border: 1px solid #ddd;
+                    padding: 15px; margin: 15px;}
               pre {background-color: #eee; border: 1px solid #ddd; padding: 5px;}
             </style>
         </head>
         <body>
             <h1>Error {{e.status}}: {{status_name}}</h1>
-            <p>Sorry, the requested URL <tt>{{repr(request.url)}}</tt> caused an error:</p>
+            <p>Sorry, the requested URL <tt>{{repr(request.url)}}</tt>
+               caused an error:</p>
             <pre>{{e.output}}</pre>
             %if DEBUG and e.exception:
               <h2>Exception:</h2>
@@ -2503,17 +2779,18 @@ ERROR_PAGE_TEMPLATE = """
         </body>
     </html>
 %except ImportError:
-    <b>ImportError:</b> Could not generate the error page. Please add bottle to sys.path
+    <b>ImportError:</b> Could not generate the error page. Please add bottle to
+    the import path.
 %end
 """
 
-#: A thread-save instance of :class:`Request` representing the `current` request.
+#: A thread-safe instance of :class:`Request` representing the `current` request.
 request = Request()
 
-#: A thread-save instance of :class:`Response` used to build the HTTP response.
+#: A thread-safe instance of :class:`Response` used to build the HTTP response.
 response = Response()
 
-#: A thread-save namepsace. Not used by Bottle.
+#: A thread-safe namespace. Not used by Bottle.
 local = threading.local()
 
 # Initialize app stack (create first empty Bottle app)
@@ -2524,3 +2801,5 @@ app.push()
 #: A virtual package that redirects import statements.
 #: Example: ``import bottle.ext.sqlite`` actually imports `bottle_sqlite`.
 ext = _ImportRedirect(__name__+'.ext', 'bottle_%s').module
+
+# THE END


### PR DESCRIPTION
Martin asked for this as ActiveRecord seems to expect Content-Type to be the same for
both request and response.
- bottle.py was updated from 0.9.6 to 0.10.dev to support this
- added a check for the content type and set a _request_data to either the resulting dict
  returned by request.json or the MultiDict returned by request.forms.  Both respond to
  'get()' so they can be used interchangeably.

Signed-off-by: Steve Loranz sloranz@redhat.com
