### PR TITLE
Initial support for snapshot of EBS to EBS

### DIFF
--- a/imgfac/builders/RHEL5_ec2_Builder.py
+++ b/imgfac/builders/RHEL5_ec2_Builder.py
@@ -48,15 +48,23 @@ class RHEL5_ec2_Builder(Fedora_ec2_Builder):
         # We don't really care about the name so just force uniqueness
         self.guest.name = self.guest.name + "-" + self.new_image_id
 
+    def ebs_pre_shapshot_tasks(self, guestaddr):
+        # The RHEL JEOS AMIs will refuse to inject the dynamic EC2 key if authorized_keys already exists
+        # We have to remove it here.
+        # NOTE: This means it is not possible for users to add a static authorized key during the build via a file or RPM
+        self.log.debug("Removing existing authorized_keys file to allow key injection on RHEL reboot")
+        self.guest.guest_execute_command(guestaddr, "[ -f /root/.ssh/authorized_keys ] && rm -f /root/.ssh/authorized_keys")
+
     def correct_remote_manifest(self, guestaddr, manifest):
         # We end up with a bogus block device mapping due to our EBS to S3 switch
         # cannot get euca-bundle-vol in RHEL5 EPEL to correct this so fix it manually - sigh
         # Remove entirely - we end up with the default root map to sda1 which is acceptable
         # TODO: Switch to a euca version that can produce sensible maps
+        self.log.debug("Removing bogus block device mapping from remote manifest")
         self.guest.guest_execute_command(guestaddr, 'perl -p -i -e "s/<block_device_mapping\>.*<\/block_device_mapping>//" %s' % (manifest))
 
     def install_euca_tools(self, guestaddr):
-        # For RHEL5 we need to enable EPEL, install, then disable EPEL
+        # For RHEL5 S3 snapshots we need to enable EPEL, install, then disable EPEL
         # TODO: This depends on external infra which is bad, and trusts external SW, which may be bad
         # For now we also mount up /mnt
         self.guest.guest_execute_command(guestaddr, "mount /dev/sdf /mnt")

--- a/imgfac/builders/RHEL6_ec2_Builder.py
+++ b/imgfac/builders/RHEL6_ec2_Builder.py
@@ -46,6 +46,13 @@ class RHEL6_ec2_Builder(Fedora_ec2_Builder):
         # We don't really care about the name so just force uniqueness
         self.guest.name = self.guest.name + "-" + self.new_image_id
 
+    def ebs_pre_shapshot_tasks(self, guestaddr):
+        # The RHEL JEOS AMIs will refuse to inject the dynamic EC2 key if authorized_keys already exists
+        # We have to remove it here.
+        # NOTE: This means it is not possible for users to add a static authorized key during the build via a file or RPM
+        self.log.debug("Removing existing authorized_keys file to allow key injection on RHEL reboot")
+        self.guest.guest_execute_command(guestaddr, "[ -f /root/.ssh/authorized_keys ] && rm -f /root/.ssh/authorized_keys")
+
     def install_euca_tools(self, guestaddr):
         # For RHEL6 we need to enable EPEL, install, then disable EPEL
         # TODO: This depends on external infra which is bad, and trusts external SW, which may be bad


### PR DESCRIPTION
This detects the JEOS AMI type when doing a snapshot.

If the JEOS AMI is EBS backed, we use the EBS-only "CreateImage" API call to create a snapshot that is also EBS backed.
