### PR TITLE
build_id for build and template on image

### DIFF
--- a/imgfac/BuildDispatcher.py
+++ b/imgfac/BuildDispatcher.py
@@ -35,7 +35,7 @@ class BuildDispatcher(Singleton):
         self.job_registry = JobRegistry()
 
     def import_image(self, image_id, build_id, target_identifier, image_desc, target, provider):
-        image_id = self._ensure_image(image_id, image_desc)
+        image_id = self._ensure_image_with_template(image_id, image_desc, Template('<template></template>'))
         build_id = self._ensure_build(image_id, build_id)
 
         target_image_id = self._ensure_target_image(build_id, target)
@@ -128,19 +128,22 @@ class BuildDispatcher(Singleton):
             return None
         return nodes[0].content
 
-    def _ensure_image_with_template(self, image_id, template):
-        name = self._xml_node(template.xml, '/template/name')
-        if name:
-            image_desc = '<image><name>%s</name></image>' % name
-        else:
-            image_desc = '</image>'
-        return self._ensure_image(image_id, image_desc)
+    def _ensure_image_with_template(self, image_id, template, image_desc=None):
+        if not image_desc:
+            name = self._xml_node(template.xml, '/template/name')
+            if name:
+                image_desc = '<image><name>%s</name></image>' % name
+            else:
+                image_desc = '<image/>'
+        if not template.identifier:
+            template.identifier = self.warehouse.store_template(template.xml)
+        return self._ensure_image(image_id, image_desc, template.identifier)
 
-    def _ensure_image(self, image_id, image_desc):
+    def _ensure_image(self, image_id, image_desc, template_id=None):
         if image_id:
             return image_id
         else:
-            return self.warehouse.store_image(None, image_desc)
+            return self.warehouse.store_image(None, image_desc, dict(template=template_id))
 
     def _ensure_build(self, image_id, build_id):
         if build_id:

--- a/imgfac/rest/imagefactory.py
+++ b/imgfac/rest/imagefactory.py
@@ -116,6 +116,8 @@ To import an image, supply target_name, provider_name, target_identifier, and im
     if(template and targets):
         log.debug("Starting 'build' process...")
         try:
+            if build_id and not image_id:
+                raise Exception("The parameter build_id must be used with a specific image_id...")
             jobs = BuildDispatcher().build_image_for_targets(image_id, build_id, template, targets.split(','))
             if(image_id):
                 base_url = request.url


### PR DESCRIPTION
1) accept and use build_id with image_id when updating an image by adding a target image to a build.  This equates to PUT on /imagefactory/images/:image_id with build_id in the PUT data.  If build_id is given, image_id must also be specified due to the current model/warehouse assumptions.  We should not change this so close to feature freeze.

2) add template uuid to the image metadata using the attribute name 'template'.  If we get the uuid of the template passed to us, we'll use that.  If we don't know the uuid, we'll store the template in warehouse and get the uuid created at that time.
