### PR TITLE
Queue builds and pushes.

### DIFF
--- a/imagefactory.conf
+++ b/imagefactory.conf
@@ -14,5 +14,7 @@
   "clients": {
     "mock-key": "mock-secret"
     },
-  "proxy_ami_id": "ami-id"
+  "proxy_ami_id": "ami-id",
+  "max_concurrent_local_sessions": 1,
+  "max_concurrent_ec2_sessions": 1
 }


### PR DESCRIPTION
In order to both avoid starting so many builds that the system running imagefactory grinds to a halt and avoid hitting the instance limit of ec2 queues have been added to ReservationManager.  The number of concurrent sessions can be set in the config file or you accept the default of single serialized sessions.  The builder delegate will check before status updates to see if the builder thread needs to enter the queue and again after state was updated to see if it needs to exit the queue.

Signed-off-by: Steve Loranz sloranz@redhat.com
