### PR TITLE
Make unit tests run with Python 2.6

### DIFF
--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -100,7 +100,7 @@ class ApplicationConfiguration(Singleton):
             sys.exit()
         elif(sys.argv[0].endswith("imagefactory")):
             return self.argparser.parse_args()
-        elif(sys.argv[0].endswith("unittest")):
+        elif(sys.argv[0].endswith("unittest" or "nosetests")):
             return self.argparser.parse_args('--image_bucket unittests_images --build_bucket unittests_builds --target_bucket unittests_target_images --template_bucket unittests_templates --icicle_bucket unittests_icicles --provider_bucket unittests_provider_images'.split())
         else:
             return self.argparser.parse_args([])

--- a/imgfac/ReservationManager.py
+++ b/imgfac/ReservationManager.py
@@ -61,8 +61,7 @@ class ReservationManager(object):
             i = super(ReservationManager, cls).__new__(cls, *p, **k)
             # initialize here, not in __init__()
             i.log = logging.getLogger('%s.%s' % (__name__, i.__class__.__name__))
-            i.default_minimum = k.get('default_minimum',
-                    p[0] if(len(p) > 0) else cls.DEFAULT_MINIMUM)
+            i.default_minimum = cls.DEFAULT_MINIMUM
             i._mounts = dict()
             i.appconfig = ApplicationConfiguration().configuration
             i._queues = dict(local=BoundedSemaphore(i.appconfig.get('max_concurrent_local_sessions', 1)),
@@ -70,7 +69,7 @@ class ReservationManager(object):
             cls.instance = i
         return cls.instance
 
-    def __init__(self, default_minimum=None):
+    def __init__(self):
         """
         @param default_minimum Default for the minimum amount needed for a path.
         """

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -9,4 +9,8 @@ Keywords: aeolus,image_factory,cloud
 
 From the top level of the image_factory source tree:
 
-	python -m unittest discover -v
+    nosetests -v
+
+Or, if you are on a system with Python 2.7 or later:
+
+    python -m unittest discover -v

--- a/tests/builders/testBaseBuilder.py
+++ b/tests/builders/testBaseBuilder.py
@@ -49,7 +49,7 @@ class TestBaseBuilder(unittest.TestCase):
 
     def testDelegateAssignment(self):
         self.builder.delegate = self.delegate
-        self.assertIs(self.builder.delegate, self.delegate)
+        self.assertEqual(id(self.builder.delegate), id(self.delegate))
 
     def testShouldUpdateStatus(self):
         self.builder.status = "UPDATE_ME"

--- a/tests/builders/testMockBuilder.py
+++ b/tests/builders/testMockBuilder.py
@@ -38,7 +38,7 @@ class TestMockBuilder(unittest.TestCase):
         self.assert_(IBuilder.implementedBy(Mock_Builder), 'Mock_Builder does not implement the ImageBuilder interface...')
 
     def testInit(self):
-        self.assertIn(self.builder.template, (self.template, self.builder.new_image_id))
+        self.assertEqual(self.builder.template, self.template)
         self.assertEqual(self.builder.target, self.target)
 
     def testBuildImage(self):

--- a/tests/qmfagent/testBuildAdaptor.py
+++ b/tests/qmfagent/testBuildAdaptor.py
@@ -28,9 +28,9 @@ class TestBuildAdaptor(unittest.TestCase):
         expected_schema_properties = ("image", "build", "status", "percent_complete", "image_id")
         expected_schema_methods = dict(abort=(), instance_states=("class_name", "states"))
         for schema_property in BuildAdaptor.qmf_schema.getProperties():
-            self.assertIn(schema_property.getName(), expected_schema_properties)
+            self.assertTrue(schema_property.getName() in expected_schema_properties)
         for schema_method in BuildAdaptor.qmf_schema.getMethods():
-            self.assertIn(schema_method.getName(), expected_schema_methods)
+            self.assertTrue(schema_property.getName() in expected_schema_properties)
             arguments = expected_schema_methods[schema_method.getName()]
             for schema_property in schema_method.getArguments():
                 self.assertIn(schema_property.getName(), arguments)

--- a/tests/qmfagent/testImageFactory.py
+++ b/tests/qmfagent/testImageFactory.py
@@ -34,15 +34,16 @@ class TestImageFactory(unittest.TestCase):
                                        import_image=("image", "build", "target_identifier", "image_desc", "target", "provider", "target_image", "provider_image"),
                                        instance_states=("class_name", "states"))
         for schema_method in ImageFactory.qmf_schema.getMethods():
-            self.assertIn(schema_method.getName(), expected_schema_methods)
+            self.assertTrue(schema_method.getName() in expected_schema_methods)
             arguments = expected_schema_methods[schema_method.getName()]
             for schema_property in schema_method.getArguments():
-                self.assertIn(schema_property.getName(), arguments)
+                self.assertTrue(schema_property.getName() in arguments)
+                    
 
     def testSingleton(self):
         image_factory_one = ImageFactory()
         image_factory_two = ImageFactory()
-        self.assertIs(image_factory_one, image_factory_two)
+        self.assertEqual(image_factory_one, image_factory_two)
         del image_factory_one
         del image_factory_two
 

--- a/tests/qmfagent/testImageFactoryAgent.py
+++ b/tests/qmfagent/testImageFactoryAgent.py
@@ -56,20 +56,14 @@ class TestImageFactoryAgent(unittest.TestCase):
         self.assertEqual(len(self.console.real_failure_events), 0, "Unexpected failure events raised!\n%s" % (self.console.real_failure_events, ))
         self.assertEqual(self.console.build_adaptor_addr_fail, self.console.test_failure_events[0]["data"]["addr"])
         # test that exceptions are passed properly by the agent handler
-        self.assertIsInstance(self.console.image_exception, Exception)
+        self.assertTrue(isinstance(self.console.image_exception, Exception))
         self.assertEqual(str(self.console.image_exception), "Wrong number of arguments: expected 2, got 0")
 
         # test that the agent registered and consoles can see it.
-        try:
-            self.assertIsNotNone(self.console.agent)
-        except AttributeError:
-            self.fail("No imagefactory agent found...")
+        self.assertTrue(self.console.agent)
 
         # test that image returns what we expect
-        try:
-            self.assertIsNotNone(self.console.build_adaptor_addr_success)
-        except AttributeError:
-            self.fail("image did not return a DataAddr for build_adaptor...")
+        self.assertTrue(self.console.build_adaptor_addr_success)
 
         # test that status changes in build adaptor create QMF events the consoles see.
         agent_name = self.console.agent.getName()
@@ -78,19 +72,16 @@ class TestImageFactoryAgent(unittest.TestCase):
             index = self.console.build_status_events.index(event)
             self.assertEqual(agent_name, event["agent"].getName())
             properties = event["data"]
-            self.assertIsNotNone(properties)
+            self.assertTrue(properties)
             self.assertEqual(self.console.build_adaptor_addr_success, properties["addr"])
             self.assertEqual(self.expected_state_transitions[index][0],properties["old_status"])
             self.assertEqual(self.expected_state_transitions[index][1],properties["new_status"])
 
         # test that provider_image returns what we expect
-        try:
-            self.assertIsNotNone(self.console.build_adaptor_addr_push)
-        except AttributeError:
-            self.fail("provider_image did not return a DataAddr for build_adaptor...")
+        self.assertTrue(self.console.build_adaptor_addr_push)
 
         # test that status changes in build adaptor create QMF events the consoles see.
-        self.assertGreater(len(self.console.push_status_events), 0)
+        self.assertTrue(len(self.console.push_status_events) > 0)
         # self.assertEqual(len(self.expected_state_transitions), len(self.console.push_status_events))
         # for event in self.console.push_status_events:
         #     index = self.console.push_status_events.index(event)
@@ -101,7 +92,7 @@ class TestImageFactoryAgent(unittest.TestCase):
         #     self.assertEqual(self.expected_state_transitions[index][0],properties["old_status"])
         #     self.assertEqual(self.expected_state_transitions[index][1],properties["new_status"])
 
-        self.assertIsNotNone(self.console.import_image_ids)
+        self.assertTrue(self.console.import_image_ids)
         self.assertEqual(len(self.console.import_image_ids), 4)
         self.assertTrue('image' in self.console.import_image_ids)
         self.assertTrue('build' in self.console.import_image_ids)
@@ -109,8 +100,8 @@ class TestImageFactoryAgent(unittest.TestCase):
         self.assertTrue('provider_image' in self.console.import_image_ids)
 
         # test instance_states method
-        self.assertIsNotNone(self.console.image_factory_states)
-        self.assertIsNotNone(self.console.build_adaptor_states)
+        self.assertTrue(self.console.image_factory_states)
+        self.assertTrue(self.console.build_adaptor_states)
 
 
 class MockConsole(ConsoleHandler):

--- a/tests/testApplicationConfiguration.py
+++ b/tests/testApplicationConfiguration.py
@@ -42,7 +42,7 @@ class TestApplicationConfiguration(unittest.TestCase):
         del self.defaults
 
     def testSingleton(self):
-        self.assertIs(ApplicationConfiguration(), ApplicationConfiguration())
+        self.assertTrue(id(ApplicationConfiguration()) == id(ApplicationConfiguration()))
 
     # def testConfigurationDictionaryDefaults(self):
     #     self.assertIsNotNone(ApplicationConfiguration().configuration)

--- a/tests/testBuildJob.py
+++ b/tests/testBuildJob.py
@@ -30,7 +30,7 @@ class testBuildJob(unittest.TestCase):
     def testInstantiateMock_Builder(self):
         template_xml = "<template><name>f14jeos</name><os><name>Fedora</name></os></template>"
         job = BuildJob.BuildJob(template_xml, "mock")
-        self.assertIsInstance(job._builder, Mock_Builder.Mock_Builder)
+        self.assertTrue(isinstance(job._builder, Mock_Builder.Mock_Builder))
         self.assertEqual(job.template.xml, template_xml)
         self.assertEqual(job.target, "mock")
 

--- a/tests/testImageWarehouse.py
+++ b/tests/testImageWarehouse.py
@@ -54,7 +54,7 @@ class testImageWarehouse(unittest.TestCase):
         template_content = "<template>This is a test template. There is not much to see here.</template>"
         # store the template and let an id get assigned
         template_id = self.warehouse.store_template(template_content)
-        self.assertIsNotNone(template_id)
+        self.assertTrue(template_id)
         # store the template with a specified id
         template_id_known = str(uuid.uuid4())
         template_id2 = self.warehouse.store_template(template_content, template_id_known)
@@ -74,7 +74,7 @@ class testImageWarehouse(unittest.TestCase):
         icicle_content = "<icicle>This is a test icicle. There is not much to see here.</icicle>"
         # store the icicle and let an id get assigned
         icicle_id = self.warehouse.store_icicle(icicle_content)
-        self.assertIsNotNone(icicle_id)
+        self.assertTrue(icicle_id)
         # store the icicle with a specified id
         icicle_id_known = str(uuid.uuid4())
         icicle_id2 = self.warehouse.store_icicle(icicle_content, icicle_id_known)
@@ -104,7 +104,7 @@ class testImageWarehouse(unittest.TestCase):
 
         image_id = self.warehouse.store_image(None, image_xml, self.metadata)
 
-        self.assertIsNotNone(image_id)
+        self.assertTrue(image_id)
 
         image_body, metadata = self.warehouse.object_with_id_of_type(image_id, 'image', self.metadata.keys())
 
@@ -120,7 +120,7 @@ class testImageWarehouse(unittest.TestCase):
 
         ids = self.warehouse.query('build', '$object_type == "build" && $key1 == "value1"')
 
-        self.assertIn(build_id, ids)
+        self.assertTrue(build_id in ids)
 
     def testBucketCreation(self):
         # self.assert_(self.warehouse.create_bucket_at_url("%s/unittests-create_bucket/%s" % (self.warehouse.url, str(uuid.uuid4()))))

--- a/tests/testReservationManager.py
+++ b/tests/testReservationManager.py
@@ -40,7 +40,7 @@ class testReservationManager(unittest.TestCase):
         fstat = os.statvfs(self.test_path)
         self.max_free = fstat.f_bavail * fstat.f_frsize
         self.min_free = self.max_free / 2
-        self.res_mgr = ReservationManager(self.min_free)
+        self.res_mgr = ReservationManager()
 
     def tearDown(self):
         self.res_mgr.remove_path(self.test_path)
@@ -51,12 +51,13 @@ class testReservationManager(unittest.TestCase):
         """
         Prove this class produces a singelton object.
         """
-        self.assertIs(self.res_mgr, ReservationManager())
+        self.assertEqual(id(self.res_mgr), id(ReservationManager()))
 
     def testDefaultMinimumProperty(self):
         """
         TODO: Docstring for testDefaultMinimumProperty
         """
+        self.res_mgr.default_minimum = self.min_free
         self.assertEqual(self.min_free, self.res_mgr.default_minimum)
 
     def testAddRemovePath(self):
@@ -79,6 +80,7 @@ class testReservationManager(unittest.TestCase):
         """
         TODO: Docstring for testReserveSpaceForFile
         """
+        self.res_mgr.default_minimum = self.min_free
         size = self.min_free / 10
         result = self.res_mgr.reserve_space_for_file(size, self.test_file)
         self.assertTrue(result)
@@ -98,6 +100,7 @@ class testReservationManager(unittest.TestCase):
         TODO: Docstring for testCancelReservationForFile
         """
         size = self.min_free / 10
+        self.res_mgr.default_minimum = self.min_free
         if(self.res_mgr.reserve_space_for_file(size, self.test_file)):
             self.assertTrue(self.test_file in self.res_mgr.reservations)
             self.res_mgr.cancel_reservation_for_file(self.test_file)
@@ -109,8 +112,7 @@ class testReservationManager(unittest.TestCase):
         """
         TODO: Docstring for testCancelNonExistentReservation
         """
-        with self.assertRaises((TypeError, KeyError)):
-            self.res_mgr.cancel_reservation_for_file('/tmp/not.there', False)
+        self.assertRaises((TypeError, KeyError), self.res_mgr.cancel_reservation_for_file, *('/tmp/not.there', False))
 
     def testAvailableSpaceForPath(self):
         """

--- a/tests/testTemplate.py
+++ b/tests/testTemplate.py
@@ -40,7 +40,7 @@ class testTemplate(unittest.TestCase):
         template = Template(template_id)
         self.assertEqual(template_id, template.identifier)
         self.assertEqual(self.template_xml, template.xml)
-        self.assertIsNone(template.url)
+        self.assertFalse(template.url)
 
     def testTemplateFromImageID(self):
         template_id = self.warehouse.store_template(self.template_xml)
@@ -53,13 +53,13 @@ class testTemplate(unittest.TestCase):
         image_template = Template(builder.new_image_id)
         self.assertEqual(template_id, image_template.identifier)
         self.assertEqual(self.template_xml, image_template.xml)
-        self.assertIsNone(template.url)
+        self.assertFalse(template.url)
 
     def testTemplateFromXML(self):
         template = Template(self.template_xml)
         self.assertEqual(self.template_xml, template.xml)
-        self.assertIsNone(template.identifier)
-        self.assertIsNone(template.url)
+        self.assertFalse(template.identifier)
+        self.assertFalse(template.url)
 
     def testTemplateFromURL(self):
         template_id = self.warehouse.store_template(self.template_xml)
@@ -75,8 +75,8 @@ class testTemplate(unittest.TestCase):
         os.close(fd)
 
         template = Template(template_path)
-        self.assertIsNone(template.url)
-        self.assertIsNone(template.identifier)
+        self.assertFalse(template.url)
+        self.assertFalse(template.identifier)
         self.assertEqual(self.template_xml, template.xml)
 
         os.remove(template_path)


### PR DESCRIPTION
These changes allow the unit tests to be run on systems with Python 2.6, such as RHEL 6 systems.

Signed-off-by: Steve Loranz sloranz@redhat.com
