### PR TITLE
remove TDL name from internal naming used when building via Oz

### DIFF
--- a/imgfac/builders/Fedora_condorcloud_Builder.py
+++ b/imgfac/builders/Fedora_condorcloud_Builder.py
@@ -61,7 +61,7 @@ class Fedora_condorcloud_Builder(BaseBuilder):
         # force uniqueness
         #  Oz now uses the tdlobject name property directly in several places
         # so we must change it
-        self.tdlobj.name = self.tdlobj.name + "-" + self.new_image_id
+        self.tdlobj.name = "factory-build-" + self.new_image_id
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior

--- a/imgfac/builders/Fedora_ec2_Builder.py
+++ b/imgfac/builders/Fedora_ec2_Builder.py
@@ -96,11 +96,14 @@ class Fedora_ec2_Builder(BaseBuilder):
         self.tdlobj = oz.TDL.TDL(xmlstring=self.template.xml, rootpw_required=True)
         # Add in target specific content
         self.add_target_content()
+
+        # Create a name combining the TDL name and the UUID for use when tagging EC2 AMIs
+        self.longname = self.tdlobj.name + "-" + self.new_image_id
         # Oz assumes unique names - TDL built for multiple backends guarantees they are not unique
         # We don't really care about the name so just force uniqueness
         # 18-Jul-2011 - Moved to constructor and modified to change TDL object name itself
         #   Oz now uses the tdlobject name property directly in several places so we must change it
-        self.tdlobj.name = self.tdlobj.name + "-" + self.new_image_id
+        self.tdlobj.name = "factory-build-" + self.new_image_id
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior
@@ -650,7 +653,7 @@ class Fedora_ec2_Builder(BaseBuilder):
             self.log.debug("De-activation complete")
 
             new_ami_id = None
-            image_name = str(self.tdlobj.name)
+            image_name = str(self.longname)
             image_desc = "%s - %s" % (asctime(localtime()), self.tdlobj.description)
 
             if ami.root_device_type == "instance-store":

--- a/imgfac/builders/Fedora_rackspace_Builder.py
+++ b/imgfac/builders/Fedora_rackspace_Builder.py
@@ -55,7 +55,7 @@ class Fedora_rackspace_Builder(BaseBuilder):
         # We don't really care about the name so just force uniqueness
         # 18-Jul-2011 - Moved to constructor and modified to change TDL object name itself
         #   Oz now uses the tdlobject name property directly in several places so we must change it
-        self.tdlobj.name = self.tdlobj.name + "-" + self.new_image_id
+        self.tdlobj.name = "factory-build-" + self.new_image_id
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior

--- a/imgfac/builders/Fedora_rhevm_Builder.py
+++ b/imgfac/builders/Fedora_rhevm_Builder.py
@@ -81,7 +81,7 @@ class Fedora_rhevm_Builder(BaseBuilder):
         # force uniqueness
         #  Oz now uses the tdlobject name property directly in several places
         # so we must change it
-        self.tdlobj.name = self.tdlobj.name + "-" + self.new_image_id
+        self.tdlobj.name = "factory-build-" + self.new_image_id
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior

--- a/imgfac/builders/Fedora_vsphere_Builder.py
+++ b/imgfac/builders/Fedora_vsphere_Builder.py
@@ -72,7 +72,7 @@ class Fedora_vsphere_Builder(BaseBuilder):
         # force uniqueness
         #  Oz now uses the tdlobject name property directly in several places
         # so we must change it
-        self.tdlobj.name = self.tdlobj.name + "-" + self.new_image_id
+        self.tdlobj.name = "factory-build-" + self.new_image_id
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior


### PR DESCRIPTION
libvirt, via Oz, uses the name field in our TDL to construct paths.  One particular
path is used as the name of Unix domain socket that monitors a qemu instance.
This path is limited to 108 characters, a limit that can easily be met by using
a long-ish name in the TDL.

There's no particular need for Oz to use a name internally that matches the
human readable name given in the TDL.  We already have to twiddle the internal
Oz name to ensure uniqueness when doing parallel builds.  This patch simply
removes any reference to the TDL name entirely.

Note that we preserve the original TDL XML when storing the template in the
warehouse, so none of this information is actually lost.
