### PR TITLE
make Oz image generation thread safe

### DIFF
--- a/imgfac/builders/Fedora_condorcloud_Builder.py
+++ b/imgfac/builders/Fedora_condorcloud_Builder.py
@@ -77,7 +77,7 @@ class Fedora_condorcloud_Builder(BaseBuilder):
         guest.name = guest.name + "-" + self.new_image_id
 
         guest.cleanup_old_guest()
-        guest.generate_install_media(force_download=False)
+        self.threadsafe_generate_install_media(guest)
         self.percent_complete=10
 
         # We want to save this later for use by RHEV-M and Condor clouds

--- a/imgfac/builders/Fedora_ec2_Builder.py
+++ b/imgfac/builders/Fedora_ec2_Builder.py
@@ -161,7 +161,7 @@ class Fedora_ec2_Builder(BaseBuilder):
         self.status="BUILDING"
         try:
             self.guest.cleanup_old_guest()
-            self.guest.generate_install_media(force_download=False)
+            self.threadsafe_generate_install_media(self.guest)
             self.percent_complete=10
 
             # We want to save this later for use by RHEV-M and Condor clouds

--- a/imgfac/builders/Fedora_rhevm_Builder.py
+++ b/imgfac/builders/Fedora_rhevm_Builder.py
@@ -97,7 +97,7 @@ class Fedora_rhevm_Builder(BaseBuilder):
         guest.name = guest.name + "-" + self.new_image_id
 
         guest.cleanup_old_guest()
-        guest.generate_install_media(force_download=False)
+        self.threadsafe_generate_install_media(guest)
         self.percent_complete=10
 
         # We want to save this later for use by RHEV-M and Condor clouds

--- a/imgfac/builders/Fedora_vsphere_Builder.py
+++ b/imgfac/builders/Fedora_vsphere_Builder.py
@@ -91,7 +91,7 @@ class Fedora_vsphere_Builder(BaseBuilder):
 
         try:
             self.guest.cleanup_old_guest()
-            self.guest.generate_install_media(force_download=False)
+            self.threadsafe_generate_install_media(self.guest)
             self.percent_complete=10
         except:
             self.log_exc()


### PR DESCRIPTION
The locking in Oz is not sufficient to make generation of install media
or modification of install media thread-safe.  This patch adds locking
around factory calls to the Oz generate_install_media() call to ensure
media download and modification tasks don't step on one another.
