### PR TITLE
ensure rc.local is executable

### DIFF
--- a/imgfac/builders/Fedora_condorcloud_Builder.py
+++ b/imgfac/builders/Fedora_condorcloud_Builder.py
@@ -144,6 +144,9 @@ class Fedora_condorcloud_Builder(BaseBuilder):
         self.log.info("Updating rc.local with Audrey conditional")
         g.write("/tmp/rc.local", self.rc_local_all)
         g.sh("cat /tmp/rc.local >> /etc/rc.local")
+        # It's possible the above line actually creates rc.local
+        # Make sure it is executable
+        g.sh("chmod a+x /etc/rc.local")
 
         # In the cloud context we currently never need or want persistent net device names
         # This is known to break networking in RHEL/VMWare and could potentially do so elsewhere

--- a/imgfac/builders/Fedora_ec2_Builder.py
+++ b/imgfac/builders/Fedora_ec2_Builder.py
@@ -386,6 +386,9 @@ class Fedora_ec2_Builder(BaseBuilder):
         self.log.info("Updating rc.local for key injection")
         g.write("/tmp/rc.local", self.rc_local)
         g.sh("cat /tmp/rc.local >> /etc/rc.local")
+        # It's possible the above line actually creates rc.local
+        # Make sure it is executable
+        g.sh("chmod a+x /etc/rc.local")
         g.rm("/tmp/rc.local")
 
         # Install menu list

--- a/imgfac/builders/Fedora_rhevm_Builder.py
+++ b/imgfac/builders/Fedora_rhevm_Builder.py
@@ -174,6 +174,9 @@ class Fedora_rhevm_Builder(BaseBuilder):
         self.log.info("Updating rc.local with Audrey conditional")
         g.write("/tmp/rc.local", self.rc_local_all)
         g.sh("cat /tmp/rc.local >> /etc/rc.local")
+        # It's possible the above line actually creates rc.local
+        # Make sure it is executable
+        g.sh("chmod a+x /etc/rc.local")
 
         # In the cloud context we currently never need or want persistent net device names
         # This is known to break networking in RHEL/VMWare and could potentially do so elsewhere

--- a/imgfac/builders/Fedora_vsphere_Builder.py
+++ b/imgfac/builders/Fedora_vsphere_Builder.py
@@ -183,6 +183,9 @@ class Fedora_vsphere_Builder(BaseBuilder):
         self.log.info("Updating rc.local with Audrey conditional")
         g.write("/tmp/rc.local", self.rc_local_all)
         g.sh("cat /tmp/rc.local >> /etc/rc.local")
+        # It's possible the above line actually creates rc.local
+        # Make sure it is executable
+        g.sh("chmod a+x /etc/rc.local")
 
         # In the cloud context we currently never need or want persistent net device names
         # This is known to break networking in RHEL/VMWare and could potentially do so elsewhere


### PR DESCRIPTION
In F16 we no longer deliver an rc.local file at all.

When we concat our Audrey conditional onto rc.local the resulting new
file is not executable.  This patch ensures that rc.local always has the
executable flag set.

TODO: Remove this when Audrey is enhanced to manage its own startup.
