### PR TITLE
add support for upload builds to sa-east-1

### DIFF
--- a/imgfac/builders/Fedora_ec2_Builder.py
+++ b/imgfac/builders/Fedora_ec2_Builder.py
@@ -1291,6 +1291,7 @@ none       /sys      sysfs   defaults         0 0
          'ec2-us-west-2':      { 'boto_loc': 'us-west-2',          'host':'us-west-2',      'i386': 'aki-dce26fec', 'x86_64': 'aki-98e26fa8' },
          'ec2-ap-southeast-1': { 'boto_loc': 'ap-southeast-1',     'host':'ap-southeast-1', 'i386': 'aki-13d5aa41', 'x86_64': 'aki-11d5aa43' },
          'ec2-ap-northeast-1': { 'boto_loc': 'ap-northeast-1',     'host':'ap-northeast-1', 'i386': 'aki-d209a2d3', 'x86_64': 'aki-d409a2d5' },
+         'ec2-sa-east-1':      { 'boto_loc': 'sa-east-1',          'host':'sa-east-1',      'i386': 'aki-bc3ce3a1', 'x86_64': 'aki-cc3ce3d1' },
          'ec2-eu-west-1':      { 'boto_loc': Location.EU,          'host':'eu-west-1',      'i386': 'aki-4deec439', 'x86_64': 'aki-4feec43b' } }
 
         # July 13 - new approach - generic JEOS AMIs for Fedora - no userdata and no euca-tools


### PR DESCRIPTION
This also uses V 1.02 of the pv-grub AKI, which is alleged to address some issues booting older 32 bit kernels.
