### PR TITLE
Bugs/bz789038

### DIFF
--- a/Documentation/ImageFactory-Rest.markdown
+++ b/Documentation/ImageFactory-Rest.markdown
@@ -361,7 +361,8 @@ _Example:_
     > > __500__ - Error getting builder list
     >
     > *Example:*  
-    > `% curl http://imgfac-host:8075/imagefactory/builders`
+    >  
+        % curl http://imgfac-host:8075/imagefactory/builders
     >
     >  
         {"_type": "builders", "href": "http://imgfac-host:8075/imagefactory/bui  


### PR DESCRIPTION
This just adds line breaks to the examples in the REST API documentation as requested in BZ789038
