### PR TITLE
make instance startup checks more robust

### DIFF
--- a/imgfac/builders/Fedora_ec2_Builder.py
+++ b/imgfac/builders/Fedora_ec2_Builder.py
@@ -650,10 +650,6 @@ class Fedora_ec2_Builder(BaseBuilder):
 
         self.instance = reservation.instances[0]
 
-        # We have occasionally seen issues when you immediately query an instance
-        # Give it 10 seconds to settle
-        sleep(10)
-
         self.wait_for_ec2_instance_start(self.instance)
 
         # From this point on we must be sure to terminate the instance when we are done
@@ -1004,10 +1000,6 @@ class Fedora_ec2_Builder(BaseBuilder):
             raise ImageFactoryException("run_instances did not result in the expected single instance - stopping")
 
         self.instance = reservation.instances[0]
-
-        # We have occasionally seen issues when you immediately query an instance
-        # Give it 10 seconds to settle
-        sleep(10)
 
         self.wait_for_ec2_instance_start(self.instance)
 


### PR DESCRIPTION
In some cases, EC2 API calls will fail if you attempt to query an
instance shortly after it has been created.  We originally worked
around this by always waiting 10 seconds before trying to query the
instance.  It seems this isn't quite long enough.

This patch works around that issue and also tries very hard to avoid
leaving a running instance behind and warns explicitly if that may
have happened.
