### PR TITLE
allow templates with version strings

### DIFF
--- a/imgfac/Template.py
+++ b/imgfac/Template.py
@@ -84,7 +84,7 @@ class Template(object):
 
         if(template_string.lower().startswith("http")):
             return "URL"
-        elif(("<template>" in template_string.lower()) and ("</template>" in template_string.lower())):
+        elif(("<template" in template_string.lower()) and ("</template>" in template_string.lower())):
             return "XML"
         elif(match):
             return "UUID"


### PR DESCRIPTION
We do a simple check in Template.py to see if a template string looks
like valid XML.  That check fails if a version property is added to
the top level <template> tag.  The version string is valid and is
something we were asked to add for consistency checking.

Allow it.
