### PR TITLE
Use OAuth if fetching template from iwhd by url

### DIFF
--- a/imgfac/ImageWarehouse.py
+++ b/imgfac/ImageWarehouse.py
@@ -88,7 +88,7 @@ class ImageWarehouse(object):
         req['oauth_signature'] = sig
         return req.to_header()
 
-    def _http_request(self, url, method, body = None, content_type = 'text/plain'):
+    def request(self, url, method, body = None, content_type = 'text/plain'):
         try:
             headers = self._oauth_headers(url, method) if self.warehouse_oauth else {}
             headers['content-type'] = content_type
@@ -103,16 +103,16 @@ class ImageWarehouse(object):
             raise WarehouseError("Problem encountered trying to reach image warehouse. Please check that iwhd is running and reachable.\nException text: %s" % (e, ))
 
     def _http_get(self, url):
-        return self._http_request(url, 'GET')[1]
+        return self.request(url, 'GET')[1]
 
     def _http_post(self, url, body, content_type):
-        return self._http_request(url, 'POST', body, content_type)[1]
+        return self.request(url, 'POST', body, content_type)[1]
 
     def _http_put(self, url, body = None):
-        self._http_request(url, 'PUT', body)[1]
+        self.request(url, 'PUT', body)[1]
 
     def create_bucket_at_url(self, url):
-        response_headers, response = self._http_request(url, 'PUT')
+        response_headers, response = self.request(url, 'PUT')
         status = int(response_headers["status"])
         if(399 < status < 600):
             # raise RuntimeError("Could not create bucket: %s" % url)
@@ -161,7 +161,7 @@ class ImageWarehouse(object):
         return object_id, the_object, metadata
 
     def delete_object_at_url(self, object_url):
-        response_headers, response = self._http_request(object_url, 'DELETE')
+        response_headers, response = self.request(object_url, 'DELETE')
         status = int(response_headers["status"])
         if(status == 200):
             return True

--- a/imgfac/Template.py
+++ b/imgfac/Template.py
@@ -117,7 +117,10 @@ class Template(object):
         if (match):
             template_id = match.group()
 
-        response_headers, response = httplib2.Http().request(url, "GET", headers={'content-type':'text/plain'})
+        if (not url.startswith(self.warehouse.url)):
+            response_headers, response = httplib2.Http().request(url, "GET", headers={'content-type':'text/plain'})
+        else:
+            response_headers, response = self.warehouse.request(url, "GET")
         if(response and self.__string_is_xml_template(response)):
             return template_id, response
         else:


### PR DESCRIPTION
Make the warehouse request method public for use in Template to take advantage of the OAuth headers.

Signed-off-by: Steve Loranz sloranz@redhat.com
