### PR TITLE
The code below this patch assumes that request_data is a dict.

### DIFF
--- a/imgfac/rest/RESTv2.py
+++ b/imgfac/rest/RESTv2.py
@@ -92,7 +92,10 @@ def list_images(image_collection, base_image_id=None, target_image_id=None, list
 @oauth_protect
 def create_image(image_collection, base_image_id=None, target_image_id=None):
     try:
-        request_data = RESTtools.form_data_for_content_type(request.headers.get('Content-Type'))
+        image_type = image_collection[0:-1]
+        request_data = RESTtools.form_data_for_content_type(request.headers.get('Content-Type')).get(image_type)
+        if(not request_data):
+            raise HTTPResponse(status=400, output='%s not found in request.' % image_type)
 
         req_base_img_id = request_data.get('base_image_id')
         req_target_img_id = request_data.get('target_image_id')


### PR DESCRIPTION
The removed code makes request_data a string if the form data has only a single key.
This happens, for example, when POSTing on base_images using a JSON dict with only a template.
