### PR TITLE
The parameters metadata key exists in all three image types.  Move it to...

### DIFF
--- a/imgfac/PersistentImage.py
+++ b/imgfac/PersistentImage.py
@@ -21,8 +21,8 @@ from Notification import Notification
 from NotificationCenter import NotificationCenter
 
 
-METADATA =  ( 'identifier', 'data', 'template', 'icicle', 'status_detail', 'status', 'percent_complete' )
-STATUS_STRINGS = ('NEW','PENDING', 'COMPLETE', 'FAILED')
+METADATA =  ( 'identifier', 'data', 'template', 'icicle', 'status_detail', 'status', 'percent_complete', 'parameters' )
+STATUS_STRINGS = ('NEW','PENDING', 'COMPLETE', 'FAILED', 'DELETING', 'DELETEFAILED')
 NOTIFICATIONS = ('image.status', 'image.percentage')
 
 
@@ -91,6 +91,7 @@ class PersistentImage(object):
         self._status = "NEW"
         self._percent_complete = 0
         self.icicle = None
+        self.parameters = None
 
     def metadata(self):
         self.log.debug("Executing metadata in class (%s) my metadata is (%s)" % (self.__class__, METADATA))

--- a/imgfac/TargetImage.py
+++ b/imgfac/TargetImage.py
@@ -18,7 +18,7 @@ from PersistentImage import PersistentImage
 from props import prop
 
 
-METADATA = ('base_image_id', 'target', 'parameters')
+METADATA = ('base_image_id', 'target')
 
 class TargetImage(PersistentImage):
     """ TODO: Docstring for TargetImage  """
@@ -31,7 +31,6 @@ class TargetImage(PersistentImage):
         super(TargetImage, self).__init__(image_id)
         self.base_image_id = None
         self.target = None
-        self.parameters = None
 
     def metadata(self):
         self.log.debug("Executing metadata in class (%s) my metadata is (%s)" % (self.__class__, METADATA))


### PR DESCRIPTION
... PersistentImage where it belongs.
