### PR TITLE
This addresses a typo and also adds the ability to specify a target for ...

### DIFF
--- a/imagefactory
+++ b/imagefactory
@@ -147,10 +147,11 @@ class Application(Singleton):
                                                                      parameters=self.app_config.get('parameters'))
                 image = builder.target_image
             elif(command == 'provider_image'):
-                builder = BuildDispatcher().builder_for_provider_image(provider=self.app_config['provider'],
-                                                                        credentials=self.app_config['credentials'],
+                builder = BuildDispatcher().builder_for_provider_image(provider=self.app_config['provider'].read(),
+                                                                        credentials=self.app_config['credentials'].read(),
+                                                                        target=self.app_config.get('target'),
                                                                         image_id=self.app_config.get('id'),
-                                                                        tempalet=template,
+                                                                        template=template,
                                                                         parameters=self.app_config.get('parameters'))
                 image = builder.provider_image
 

--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -83,6 +83,7 @@ class ApplicationConfiguration(Singleton):
             provider_group.add_argument('--id', help='The uuid of the TargetImage to push.')
             provider_group.add_argument('--template', type=argparse.FileType(), help=template_help)
             cmd_provider.add_argument('--parameters')
+            cmd_provider.add_argument('--target', help='The target type of the given provider')
 
             cmd_list = subparsers.add_parser('images', help='List images of a given type or get details of an image.')
             cmd_list.add_argument('fetch_spec', help='JSON formatted string of key/value pairs')


### PR DESCRIPTION
...the push, which is currently a requirement.

We have talked about folding target into the ad-hoc provider definition, which I think is the right long-term solution.

In the meantime, in order for the CLI to work, these changes need to go in.
