### PR TITLE
Create /boot/grub/menu.lst for Fedora-18 images

### DIFF
--- a/imagefactory_plugins/EC2Cloud/EC2Cloud.py
+++ b/imagefactory_plugins/EC2Cloud/EC2Cloud.py
@@ -454,6 +454,11 @@ class EC2Cloud(object):
         tmpl = string.replace(tmpl, "#KERNEL_IMAGE_NAME#", ramfs_prefix)
         tmpl = string.replace(tmpl, "#TITLE#", name)
 
+        # Starting F18 there is no menu.lst
+        if not g.exists("/boot/grub/menu.lst"):
+            g.sh("[ ! -d /boot/grub ] && mkdir /boot/grub ||:")
+            g.sh("echo > /boot/grub/menu.lst")
+
         g.write("/boot/grub/menu.lst", tmpl)
 
         # EC2 Xen nosegneg bug


### PR DESCRIPTION
I've tried creating F18 images and ran into this:

  File "/usr/lib/python2.6/site-packages/imagefactory_plugins/EC2Cloud/EC2Cloud.py", line 152, in builder_did_create_target_image
    self.ec2_modify_filesystem()
  File "/usr/lib/python2.6/site-packages/imagefactory_plugins/EC2Cloud/EC2Cloud.py", line 457, in ec2_modify_filesystem
    g.write("/boot/grub/menu.lst", tmpl)
  File "/usr/lib/python2.6/site-packages/guestfs.py", line 5089, in write
    return libguestfsmod.write (self._o, path, content)
RuntimeError: write: open: /boot/grub/menu.lst: No such file or directory

My tiny patch is intended to fix this small issue.
