### PR TITLE
Allow custom install script (ks.cfg) and configurable ICICLE generation

### DIFF
--- a/imagefactory_plugins/FedoraOS/FedoraOS.py
+++ b/imagefactory_plugins/FedoraOS/FedoraOS.py
@@ -112,7 +112,7 @@ class FedoraOS(object):
         try:
             self.log.debug("Doing second-stage target_image customization and ICICLE generation")
             #self.percent_complete = 30
-            self.output_descriptor = self.guest.customize_and_generate_icicle(libvirt_xml)
+            builder.target_image.icicle = self.guest.customize_and_generate_icicle(libvirt_xml)
             self.log.debug("Customization and ICICLE generation complete")
             #self.percent_complete = 50
         finally:
@@ -300,9 +300,9 @@ class FedoraOS(object):
                 # Power users may wish to avoid ever booting the guest after the installer is finished
                 # They can do so by passing in a { "generate_icicle": False } KV pair in the parameters dict
                 if self.parameters.get("generate_icicle", True):
-                    self.output_descriptor = self.guest.customize_and_generate_icicle(libvirt_xml)
+                    builder.base_image.icicle = self.guest.customize_and_generate_icicle(libvirt_xml)
                 else:
-                    self.output_descriptor = self.guest.customize(libvirt_xml)
+                    self.guest.customize(libvirt_xml)
                 self.log.debug("Customization and ICICLE generation complete")
                 self.percent_complete = 50
             finally:

--- a/imgfac/Builder.py
+++ b/imgfac/Builder.py
@@ -212,6 +212,9 @@ class Builder(object):
             if self.base_image.status != "COMPLETE":
                 raise ImageFactoryException("Got to TargetImage build step with a BaseImage status of (%s).  This should never happen.  Aborting." % (self.base_image.status))
 
+            # Only at this point can we be sure that our base_image has icicle associated with it
+            self.target_image.icicle = self.base_image.icicle
+
             template = template if(isinstance(template, Template)) else Template(template)
 
             plugin_mgr = PluginManager(self.app_config['plugins'])
@@ -328,6 +331,9 @@ class Builder(object):
 
             if self.target_image.status != "COMPLETE":
                 raise ImageFactoryException("Got to ProviderImage build step with a TargetImage status of (%s).  This should never happen.  Aborting." % (self.target_image.status))
+
+            # Only at this point can we be sure that our target_image has icicle associated with it
+            self.provider_image.icicle = self.target_image.icicle
 
             template = template if(isinstance(template, Template)) else Template(template)
 


### PR DESCRIPTION
We have repeatedly been asked to support modification of the kickstart used in the
first stage of the image building process.  This adds an "install_script" parameter
to allow that to happen.  An earlier patch set makes the existing cloud plugins
more flexible about the partition layout of incoming base images, which should allow
a wider variety of custom ks.cfg files to work.

This also adds a "generate_icicle" parameter that defaults to True but can be set
to false.  If it is false, we will not generate ICICLE.  If this is combined with
a TDL that contains no repo, package, file or command customizations, the KVM guest
will not be restarted after the initial Anaconda install finishes.  This will allow
us to support use cases, including a proposed LiveCD "provider" that will benefit
from having access to the "raw" Anaconda results.
