### PR TITLE
Fixed support for F18 as suggested by vittyvk

### DIFF
--- a/imagefactory_plugins/EC2/EC2.py
+++ b/imagefactory_plugins/EC2/EC2.py
@@ -448,6 +448,12 @@ class EC2(object):
         tmpl = string.replace(tmpl, "#KERNEL_IMAGE_NAME#", ramfs_prefix)
         tmpl = string.replace(tmpl, "#TITLE#", name)
 
+        if not g.is_dir("/boot/grub"):
+            try:
+                g.mkdir_p("/boot/grub")
+            except RuntimeError:
+                raise ImageFactoryException("Unable to create /boot/grub directory - aborting")
+
         g.write("/boot/grub/menu.lst", tmpl)
 
         # EC2 Xen nosegneg bug


### PR DESCRIPTION
Original pull request: https://github.com/aeolusproject/imagefactory/pull/260

Re-implemented it using libguestfs native calls instead of executing commands using guestfs.sh().
