### PR TITLE
force urls from jeos config to be strings

### DIFF
--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -189,7 +189,7 @@ class ApplicationConfiguration(Singleton):
         log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
         config_urls = self.configuration['jeos_config']
         for url in config_urls:
-            filehandle = urlopen(url)
+            filehandle = urlopen(str(url))
             line = filehandle.readline().strip()
             line_number = 1
 


### PR DESCRIPTION
In RHEL 6 the url grab fails without this because, presumably, it is being passed a unicode
string.  Adding the str() wrapper resolves this and should be harmless.
