### PR TITLE
Make vSphere ovf metadata compatible with vSphere 4 and 5

### DIFF
--- a/imagefactory_plugins/ovfcommon/ovfcommon.py
+++ b/imagefactory_plugins/ovfcommon/ovfcommon.py
@@ -442,8 +442,8 @@ class VsphereOVFDescriptor(object):
         # TODO this should be dynamic
         etossec = ElementTree.Element('OperatingSystemSection')
         etossec.set('ovf:id', '80')
-        etossec.set('ovf:version', '5')
-        etossec.set('vmw:osType', 'rhel5_64Guest')
+        etossec.set('ovf:version', '6')
+        etossec.set('vmw:osType', 'rhel6_64Guest')
 
         etinfo = ElementTree.Element('Info')
         etinfo.text = 'The kind of installed guest operating system'
@@ -472,7 +472,7 @@ class VsphereOVFDescriptor(object):
         etsystem.append(etvirtsysid)
 
         etvirtsystype = ElementTree.Element('vssd:VirtualSystemType')
-        etvirtsystype.text = 'vmx-04' #maybe not hardcode this?
+        etvirtsystype.text = 'vmx-07 vmx-08' #maybe not hardcode this?
         etsystem.append(etvirtsystype)
 
         etvirthwsec.append(etsystem)


### PR DESCRIPTION
This change to the metadata allows import of the OVA to both
vSphere 4 and vSphere 5 without warning, and more accurately
represents the operating system type.
