### PR TITLE
improve plugin error messages

### DIFF
--- a/imgfac/PluginManager.py
+++ b/imgfac/PluginManager.py
@@ -136,6 +136,8 @@ class PluginManager(Singleton):
             if isinstance(target, str):
                 self.log.debug("Attempting to match string target (%s)" % target)
                 plugin_name = self._targets.get(tuple([target]))
+                if not plugin_name:
+                    raise ImageFactoryException("No plugin .info file loaded for target: %s" % (target))
                 plugin = __import__('%s.%s' % (PKG_STR, plugin_name), fromlist=['delegate_class'])
                 return plugin.delegate_class()
             elif isinstance(target, tuple):
@@ -148,5 +150,7 @@ class PluginManager(Singleton):
                     else:
                         plugin = __import__('%s.%s' % (PKG_STR, plugin_name), fromlist=['delegate_class'])
                         return plugin.delegate_class()
-        except ImportError:
-            raise ImageFactoryException("Unable to find plugin for target: %s" % str(target))
+        except ImportError as e:
+            self.log.exception(e)
+            raise ImageFactoryException("Unable to import plugin for target: %s" % str(target))
+


### PR DESCRIPTION
Without this change it's impossible to know exactly why a plugin load failed.

This changes the manager to:

throw a specific error if the plugin is not found in the loaded .info file list
throw a specific error if we are unable to import the plugin
log the traceback when an import fails
