### PR TITLE
add ability to specify individual parameters on cmdline without JSON

### DIFF
--- a/imagefactory
+++ b/imagefactory
@@ -20,6 +20,7 @@ import logging
 import signal
 import os
 import json
+import pprint
 from time import asctime, localtime
 from imgfac.Singleton import Singleton
 from imgfac.ApplicationConfiguration import ApplicationConfiguration
@@ -172,6 +173,23 @@ class Application(Singleton):
                 sys.exit(1)
         else:
             parameters={ }
+
+        # Note that this means individually specified parameters or file-parameters will
+        # override what is in the original --parameters JSON file if it exists
+	if self.app_config.get('parameter'):
+	    for parpair in self.app_config.get('parameter'):
+		parameters[parpair[0]] = parpair[1]
+
+	if self.app_config.get('file_parameter'):
+	    for parpair in self.app_config.get('file_parameter'):
+		try:
+		    parameters[parpair[0]] = open(parpair[1]).read()
+		except:
+		    logging.error("Unable to read file %s referenced in --file-parameter argument" % (parpair[1]))
+		    sys.exit(1)
+
+        logging.debug("Parameters are:")
+        logging.debug("\n%s" % (pprint.pformat(parameters)))
 
         if(command in ('base_image', 'target_image', 'provider_image')):
             template = None

--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -91,18 +91,17 @@ class ApplicationConfiguration(Singleton):
             argparser.add_argument('--raw', action='store_true', default=False, help='Turn off pretty printing.')
             subparsers = argparser.add_subparsers(title='commands', dest='command')
             template_help = 'A file containing the image template or component outline, compatible with the TDL schema (http://imgfac.org/documentation/tdl).'
-            parameters_help = 'An optional JSON file containing additional parameters to pass to the builders.'
 
             cmd_base = subparsers.add_parser('base_image', help='Build a generic image.')
             cmd_base.add_argument('template', type=argparse.FileType(), help=template_help)
-            cmd_base.add_argument('--parameters', type=argparse.FileType(), help=parameters_help)
+            self.__add_param_arguments(cmd_base)
 
             cmd_target = subparsers.add_parser('target_image', help='Customize an image for a given cloud.')
             cmd_target.add_argument('target', help='The name of the target cloud for which to customize the image.')
             target_group = cmd_target.add_mutually_exclusive_group(required=True)
             target_group.add_argument('--id', help='The uuid of the BaseImage to customize.')
             target_group.add_argument('--template', type=argparse.FileType(), help=template_help)
-            cmd_target.add_argument('--parameters', type=argparse.FileType(), help=parameters_help)
+            self.__add_param_arguments(cmd_target)
 
             cmd_provider = subparsers.add_parser('provider_image', help='Push an image to a cloud provider.')
             cmd_provider.add_argument('target', help='The target type of the given cloud provider')
@@ -111,7 +110,7 @@ class ApplicationConfiguration(Singleton):
             provider_group = cmd_provider.add_mutually_exclusive_group(required=True)
             provider_group.add_argument('--id', help='The uuid of the TargetImage to push.')
             provider_group.add_argument('--template', type=argparse.FileType(), help=template_help)
-            cmd_provider.add_argument('--parameters', type=argparse.FileType(), help=parameters_help)
+            self.__add_param_arguments(cmd_provider)
             cmd_provider.add_argument('--snapshot', action='store_true', default=False, help='Use snapshot style building. (default: %(default)s)')
 
             cmd_list = subparsers.add_parser('images', help='List images of a given type or get details of an image.')
@@ -122,11 +121,18 @@ class ApplicationConfiguration(Singleton):
             cmd_delete.add_argument('--provider', help="A file containing the cloud provider description or a string literal starting with '@' such as '@ec2-us-east-1'.")
             cmd_delete.add_argument('--credentials', type=argparse.FileType(), help='A file containing the cloud provider credentials')
             cmd_delete.add_argument('--target', help='The name of the target cloud for which to customize the image.')
-            cmd_delete.add_argument('--parameters', type=argparse.FileType(), help=parameters_help)
+            self.__add_param_arguments(cmd_delete)
 
             cmd_plugins = subparsers.add_parser('plugins', help='List active plugins or get details of a specific plugin.')
             cmd_plugins.add_argument('--id')
         return argparser
+
+    def __add_param_arguments(self, parser):
+        # We do this for all three image types so lets make it a util function
+        parameters_help = 'An optional JSON file containing additional parameters to pass to the builders.'
+        parser.add_argument('--parameters', type=argparse.FileType(), help=parameters_help)
+        parser.add_argument('--parameter', nargs=2, action='append', help='A parameter name and the literal value to assign it.  Can be used more than once.')
+        parser.add_argument('--file-parameter', nargs=2, action='append', help='A parameter name and a file to insert into it.  Can be used more than once.')
 
     def __parse_arguments(self):
         appname = sys.argv[0].rpartition('/')[2]


### PR DESCRIPTION
This should allow most command line uses of the parameters to occur
without the user having to generate a JSON file to be passed in the
--parameters argument.

For example, a kickstart can now be specified to the base_image generation
like this:

imagefactory base_image --parameter-file install_script kickstart.ks input.tdl

Or icicle generation can be disabled like this:

imagefactory base_image --parameter generate_icicle 0 input.tdl

TODO: Have the plugins specify what parameters they accept and what the default
      values are.
