### PR TITLE
rework IndirectionCloud to be compatible with Oz migration to lxml

### DIFF
--- a/imagefactory_plugins/imagefactory-plugins.spec.in
+++ b/imagefactory_plugins/imagefactory-plugins.spec.in
@@ -58,7 +58,7 @@ archive from.
 %package IndirectionCloud
 Summary: Cloud plugin for allowing images to modify other images
 License: ASL 2.0
-Requires: oz >= 0.7.0
+Requires: oz >= 0.12.0
 Requires: imagefactory-plugins
 Requires: imagefactory-plugin-api = 1.0
 
@@ -72,7 +72,7 @@ arbitrary  host OS and package selection for the actual media creation tools.
 %package TinMan
 Summary: OS plugin for Fedora
 License: ASL 2.0
-Requires: oz >= 0.7.0
+Requires: oz >= 0.12.0
 Requires: imagefactory-plugins
 Requires: imagefactory-plugin-api = 1.0
 


### PR DESCRIPTION
We are tightly integrated with Oz/TinMan for this plugin.  This includes
directly passing parsed XML objects into Oz functions.  The switch to lxml
in Oz broke some of these calls.  This patch fixes it.

This also changes the RPM packaging to force Oz >= 0.12.0 which is the
first Oz release version to use the lxml changes.
