### PR TITLE
make TinMan interpret string and integer parameters as bool where necess...

### DIFF
--- a/imagefactory_plugins/TinMan/TinMan.py
+++ b/imagefactory_plugins/TinMan/TinMan.py
@@ -30,6 +30,7 @@ from imgfac.ImageFactoryException import ImageFactoryException
 from imgfac.ReservationManager import ReservationManager
 from imgfac.FactoryUtils import launch_inspect_and_mount, shutdown_and_close, remove_net_persist
 from imgfac.OSDelegate import OSDelegate
+from imgfac.FactoryUtils import parameter_cast_to_bool
 from libvirt import libvirtError
 from oz.OzException import OzException
 
@@ -336,8 +337,8 @@ class TinMan(object):
                 self.percent_complete = 30
                 # Power users may wish to avoid ever booting the guest after the installer is finished
                 # They can do so by passing in a { "generate_icicle": False } KV pair in the parameters dict
-                if self.parameters.get("generate_icicle", True):
-                    if self.parameters.get("offline_icicle", False):
+                if parameter_cast_to_bool(self.parameters.get("generate_icicle", True)):
+                    if parameter_cast_to_bool(self.parameters.get("offline_icicle", False)):
                         self.guest.customize(libvirt_xml)
                         gfs = launch_inspect_and_mount(self.image, readonly=True)
                         # Monkey-patching is bad

--- a/imgfac/FactoryUtils.py
+++ b/imgfac/FactoryUtils.py
@@ -154,3 +154,29 @@ def enable_root(guestaddr, sshprivkey, user, prefix):
             raise Exception('Running /bin/id on %s as root: %s' % (guestaddr, stdout))
     except Exception as e:
         raise ImageFactoryException('Transfer of authorized_keys to root from %s must have failed - Aborting - %s' % (user, e))
+
+# Our generic "parameters" dict passed to the plugins may be derived from either
+# real JSON or from individual parameters passed on the command line.  In the case
+# of command line parameters, all dict values are strings.  Plugins that want to
+# accept non-string parameters should be prepared to do a string conversion.
+
+def parameter_cast_to_bool(ival):
+    """
+    Function to take an input that may be a string, an int or a bool
+    If input is a string it is made lowecase
+    Returns True if ival is boolean True, a non-zero integer, "Yes",
+    "True" or "1"
+    Returns False in ival is boolean False, zero, "No", "False" or "0"
+    In all other cases, returns None
+    """
+    if type(ival) is bool:
+        return ival
+    if type(ival) is int:
+        return bool(ival)
+    if type(ival) is str:
+        lower = ival.lower()
+        if lower == 'no' or lower == 'false' or lower == '0':
+            return False
+        if lower == 'yes' or lower == 'true' or lower == '1':
+            return True
+    return None


### PR DESCRIPTION
...ary

Per the code comments, this is needed to allow the newly expanded CLI options
for parameters passing to work correctly.

What we should really do is make each plugin specify what parameters it can
accept, what the type is and what the defaults should be and then do strict
validation or casting of the incoming data.

TODO: Add that to the backlog
