### PR TITLE
First cut at Nova plugin

### DIFF
--- a/imagefactory
+++ b/imagefactory
@@ -151,7 +151,7 @@ class Application(Singleton):
         # This returns the contents of the credentials_file
         # If credentials file is not provided return None
         if not credentials_file:
-	    return None
+            return None
         # If credentials file is provided, try to read contents
         else:
             ret_credentials = credentials_file.read().rstrip()
@@ -176,17 +176,17 @@ class Application(Singleton):
 
         # Note that this means individually specified parameters or file-parameters will
         # override what is in the original --parameters JSON file if it exists
-	if self.app_config.get('parameter'):
-	    for parpair in self.app_config.get('parameter'):
-		parameters[parpair[0]] = parpair[1]
+        if self.app_config.get('parameter'):
+            for parpair in self.app_config.get('parameter'):
+                parameters[parpair[0]] = parpair[1]
 
-	if self.app_config.get('file_parameter'):
-	    for parpair in self.app_config.get('file_parameter'):
-		try:
-		    parameters[parpair[0]] = open(parpair[1]).read()
-		except:
-		    logging.error("Unable to read file %s referenced in --file-parameter argument" % (parpair[1]))
-		    sys.exit(1)
+        if self.app_config.get('file_parameter'):
+            for parpair in self.app_config.get('file_parameter'):
+                try:
+                    parameters[parpair[0]] = open(parpair[1]).read()
+                except:
+                    logging.error("Unable to read file %s referenced in --file-parameter argument" % (parpair[1]))
+                    sys.exit(1)
 
         logging.debug("Parameters are:")
         logging.debug("\n%s" % (pprint.pformat(parameters)))

--- a/imagefactory_plugins/Nova/Nova.info
+++ b/imagefactory_plugins/Nova/Nova.info
@@ -1,0 +1,14 @@
+{
+    "type": "os",
+    "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null], ["RHEL-7", null, null],
+                 ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null], ["Windows", null, null]
+               ],
+    "description": "Plugin to support building OS base images using OpenStack Nova.",
+    "maintainer": {
+        "name": "Red Hat, Inc.",
+        "email": "imagefactory-devel@lists.fedorahosted.org",
+        "url": "http://imgfac.org"
+    },
+    "version": "1.0",
+    "license": "Copyright 2012 Red Hat, Inc. - http://www.apache.org/licenses/LICENSE-2.0"
+}

--- a/imagefactory_plugins/Nova/Nova.py
+++ b/imagefactory_plugins/Nova/Nova.py
@@ -1,0 +1,155 @@
+# encoding: utf-8
+#
+#   Copyright 2014 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import logging
+import zope
+import os.path
+import shutil
+from imgfac.ApplicationConfiguration import ApplicationConfiguration
+from imgfac.OSDelegate import OSDelegate
+from imgfac.ImageFactoryException import ImageFactoryException
+from novaimagebuilder.Builder import Builder as NIB
+from novaimagebuilder.StackEnvironment import StackEnvironment
+
+PROPERTY_NAME_GLANCE_ID = 'x-image-properties-glance_id'
+
+
+class Nova(object):
+    """
+    Nova implements the ImageFactory OSDelegate interface for the Nova plugin.
+    """
+    zope.interface.implements(OSDelegate)
+
+    def __init__(self):
+        super(Nova, self).__init__()
+        self.app_config = ApplicationConfiguration().configuration
+        self.log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
+        self.nib = None
+        self._cloud_plugin_content = []
+
+    def abort(self):
+        """
+        Abort the current operation.
+        """
+        if self.nib and isinstance(self.nib, NIB):
+            status = self.nib.abort()
+            self.log.debug('aborting... status: %s' % status)
+        else:
+            self.log.debug('No active Nova Image Builder instance found, nothing to abort.')
+
+    def create_base_image(self, builder, template, parameters):
+        """
+        Create a JEOS image and install any packages specified in the template.
+
+        @param builder The Builder object coordinating image creation.
+        @param template A Template object.
+        @param parameters Dictionary of target specific parameters.
+
+        @return A BaseImage object.
+        """
+        self.log.info('create_base_image() called for Nova plugin - creating a BaseImage')
+
+        self.log.debug('Nova.create_base_image() called by builder (%s)' % builder)
+        if not parameters:
+            parameters = {}
+        self.log.debug('parameters set to %s' % parameters)
+
+        builder.base_image.update(5, 'PENDING', 'Collecting build arguments to pass to Nova Image Builder...')
+        # Derive the OSInfo OS short_id from the os_name and os_version in template
+        if template.os_version:
+            if template.os_name[-1].isdigit():
+                install_os = '%s.%s' % (template.os_name, template.os_version)
+            else:
+                install_os = '%s%s' % (template.os_name, template.os_version)
+        else:
+            install_os = template.os_name
+
+        install_os = install_os.lower()
+
+        install_location = template.install_location
+        # TDL uses 'url' but Nova Image Builder uses 'tree'
+        install_type = 'tree' if template.install_type == 'url' else template.install_type
+        install_script = parameters.get('install_script')
+        install_config = {'admin_password': parameters.get('admin_password'),
+                          'license_key': parameters.get('license_key'),
+                          'arch': template.os_arch,
+                          'disk_size': parameters.get('disk_size'),
+                          'flavor': parameters.get('flavor'),
+                          'storage': parameters.get('storage'),
+                          'name': template.name,
+                          'direct_boot': False}
+
+        builder.base_image.update(10, 'BUILDING', 'Created Nova Image Builder instance...')
+        self.nib = NIB(install_os, install_location, install_type, install_script, install_config)
+        self.nib.run()
+
+        builder.base_image.update(10, 'BUILDING', 'Waiting for Nova Image Builder to complete...')
+        os_image_id = self.nib.wait_for_completion(180)
+        if os_image_id:
+            builder.base_image.properties[PROPERTY_NAME_GLANCE_ID] = os_image_id
+            builder.base_image.update(100, 'COMPLETE', 'Image stored in glance with id (%s)' % os_image_id)
+        else:
+            exc_msg = 'Nova Image Builder failed to return a Glance ID, failing...'
+            builder.base_image.update(status='FAILED', error=exc_msg)
+            self.log.exception(exc_msg)
+            raise ImageFactoryException(exc_msg)
+
+    def create_target_image(self, builder, target, base_image, parameters):
+        """
+        *** NOT YET IMPLEMENTED ***
+        Performs cloud specific customization on the base image.
+
+        @param builder The builder object.
+        @param base_image The BaseImage to customize.
+        @param target The cloud type to customize for.
+        @param parameters Dictionary of target specific parameters.
+
+        @return A TargetImage object.
+        """
+        self.log.info('create_target_image() currently unsupported for Nova plugin')
+
+        ### TODO: Snapshot the image in glance, launch in nova, and ssh in to customize.
+        # The following is incomplete and not correct as it assumes local manipulation of the image
+        # self.log.info('create_target_image() called for Nova plugin - creating TargetImage')
+        # base_img_path = base_image.data
+        # target_img_path = builder.target_image.data
+        #
+        # builder.target_image.update(status='PENDING', detail='Copying base image...')
+        # if os.path.exists(base_img_path) and os.path.getsize(base_img_path):
+        #     try:
+        #         shutil.copyfile(base_img_path, target_img_path)
+        #     except IOError as e:
+        #         builder.target_image.update(status='FAILED', error='Error copying base image: %s' % e)
+        #         self.log.exception(e)
+        #         raise e
+        # else:
+        #     glance_id = base_image.properties[PROPERTY_NAME_GLANCE_ID]
+        #     base_img_file = StackEnvironment().download_image_from_glance(glance_id)
+        #     with open(builder.target_image.data, 'wb') as target_img_file:
+        #         shutil.copyfileobj(base_img_file, target_img_file)
+        #     base_img_file.close()
+
+    def add_cloud_plugin_content(self, content):
+        """
+        This is a method that cloud plugins can call to deposit content/commands to
+        be run during the OS-specific first stage of the Target Image creation.
+
+        There is no support for repos at the moment as these introduce external
+        dependencies that we may not be able to resolve.
+
+        @param content dict containing commands and file.
+        """
+        self._cloud_plugin_content.append(content)

--- a/imagefactory_plugins/Nova/__init__.py
+++ b/imagefactory_plugins/Nova/__init__.py
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+#   Copyright 2012 Red Hat, Inc.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from Nova import Nova as delegate_class

--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -196,25 +196,24 @@ class ApplicationConfiguration(Singleton):
         log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
         config_urls = self.configuration['jeos_config']
         # Expand directories from the config and url-ify files
-	# Read inlist - replace directories with their contents
-	nextlist = [ ]
-	for path in config_urls:
-	    if os.path.isdir(path):
-		for filename in os.listdir(path):
-		    fullname = os.path.join(path, filename)
-		    if os.path.isfile(fullname):
-			nextlist.append(fullname)
-	    else:
-		nextlist.append(path)
+        # Read inlist - replace directories with their contents
+        nextlist = []
+        for path in config_urls:
+            if os.path.isdir(path):
+                for filename in os.listdir(path):
+                    fullname = os.path.join(path, filename)
+                    if os.path.isfile(fullname):
+                        nextlist.append(fullname)
+            else:
+                nextlist.append(path)
 
-	# Read nextlist - replace files with file:// URLs
-	finalist = [ ]
-	for path in nextlist:
-	    if os.path.isfile(path):
-		finalist.append("file://" + path)
-	    else:
-		finalist.append(path)
-
+        # Read nextlist - replace files with file:// URLs
+        finalist = []
+        for path in nextlist:
+            if os.path.isfile(path):
+                finalist.append("file://" + path)
+            else:
+                finalist.append(path)
 
         for url in finalist:
             try:

--- a/imgfac/OSDelegate.py
+++ b/imgfac/OSDelegate.py
@@ -28,6 +28,7 @@ class OSDelegate(Interface):
 
         @param builder The Builder object coordinating image creation.
         @param template A Template object.
+        @param parameters Dictionary of target specific parameters.
 
         @return A BaseImage object.
         """
@@ -46,5 +47,11 @@ class OSDelegate(Interface):
 
     def add_cloud_plugin_content(self, content):
         """
-        TODO: Describe add_cloud_plugin_content
+        This is a method that cloud plugins can call to deposit content/commands to
+        be run during the OS-specific first stage of the Target Image creation.
+
+        There is no support for repos at the moment as these introduce external
+        dependencies that we may not be able to resolve.
+
+        @param content dict containing commands and file.
         """

--- a/imgfac/PersistentImage.py
+++ b/imgfac/PersistentImage.py
@@ -21,8 +21,9 @@ from Notification import Notification
 from NotificationCenter import NotificationCenter
 
 
-METADATA =  ( 'identifier', 'data', 'template', 'icicle', 'status_detail', 'status', 'percent_complete', 'parameters' )
-STATUS_STRINGS = ('NEW','PENDING', 'BUILDING', 'COMPLETE', 'FAILED', 'DELETING', 'DELETED', 'DELETEFAILED')
+METADATA = ('identifier', 'data', 'template', 'icicle', 'status_detail', 'status', 'percent_complete', 'parameters',
+            'properties')
+STATUS_STRINGS = ('NEW', 'PENDING', 'BUILDING', 'COMPLETE', 'FAILED', 'DELETING', 'DELETED', 'DELETEFAILED')
 NOTIFICATIONS = ('image.status', 'image.percentage')
 
 
@@ -36,18 +37,21 @@ class PersistentImage(object):
     template = prop("_template")
     icicle = prop("_icicle")
     status_detail = prop("_status_detail")
+    parameters = prop("_parameters")
+    properties = prop("_properties")
 
     def status():
         doc = "A string value."
+
         def fget(self):
             return self._status
 
         def fset(self, value):
             value = value.upper()
-            if(value == self._status):
+            if value == self._status:
                 # Do not update or send a notification if nothing has changed
                 return
-            if(value in STATUS_STRINGS):
+            if value in STATUS_STRINGS:
                 old_value = self._status
                 self._status = value
                 notification = Notification(message=NOTIFICATIONS[0],
@@ -62,6 +66,7 @@ class PersistentImage(object):
 
     def percent_complete():
         doc = "The percentage through an operation."
+
         def fget(self):
             return self._percent_complete
 
@@ -91,13 +96,23 @@ class PersistentImage(object):
         # 'activity' should be set to a single line indicating, in as much detail as reasonably possible,
         #   what it is that the plugin operating on this image is doing at any given time.
         # 'error' should remain None unless an exception or other fatal error has occurred.  Error may
-        #   be a multiline string
-        self.status_detail = { 'activity': 'Initializing image prior to Cloud/OS customization', 'error':None }
+        #   be a multi-line string
+        self.status_detail = {'activity': 'Initializing image prior to Cloud/OS customization', 'error': None}
         # Setting these to None or setting initial value via the properties breaks the prop code above
         self._status = "NEW"
         self._percent_complete = 0
         self.icicle = None
-        self.parameters = { }
+        self.parameters = {}
+        self.properties = {}
+
+    def update(self, percentage=None, status=None, detail=None, error=None):
+        if percentage:
+            self.percent_complete = percentage
+        if status:
+            self.status = status
+        if detail:
+            self.status_detail['activity'] = detail
+        self.status_detail['error'] = error
 
     def metadata(self):
         self.log.debug("Executing metadata in class (%s) my metadata is (%s)" % (self.__class__, METADATA))

--- a/imgfac/Template.py
+++ b/imgfac/Template.py
@@ -44,6 +44,26 @@ class Template(object):
     def os_arch(self):
         """The property os_arch"""
         return self._content_at_path('/template/os/arch')
+    @property
+    def install_type(self):
+        """The type of install ('url' or 'iso')"""
+        result = libxml2.parseDoc(self.xml).xpathEval('/template/os/install')[0]
+        if result:
+            return result.prop('type')
+        else:
+            return None
+    @property
+    def install_url(self):
+        """OS install URL"""
+        return self._content_at_path('/template/os/install/url')
+    @property
+    def install_iso(self):
+        """OS install ISO"""
+        return self._content_at_path('/template/os/install/iso')
+    @property
+    def install_location(self):
+        """Either OS install URL or ISO"""
+        return self._content_at_path('/template/os/install/%s' % self.install_type)
 
     def __repr__(self):
         if(self.xml):

--- a/scripts/imagefactory_dev_setup.sh
+++ b/scripts/imagefactory_dev_setup.sh
@@ -17,6 +17,11 @@ sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/OpenStack/OpenStack.info" $IM
 sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/MockCloud/MockCloud.info" $IMAGEFACTORY_PLUGINS/MockCloud.info
 sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/RHEVM/RHEVM.info" $IMAGEFACTORY_PLUGINS/RHEVM.info
 sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/vSphere/vSphere.info" $IMAGEFACTORY_PLUGINS/vSphere.info
+sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Rackspace/Rackspace.info" $IMAGEFACTORY_PLUGINS/Rackspace.info
+sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/OVA/OVA.info" $IMAGEFACTORY_PLUGINS/OVA.info
+sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/IndirectionCloud/IndirectionCloud.info" $IMAGEFACTORY_PLUGINS/IndirectionCloud.info
+sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Docker/Docker.info" $IMAGEFACTORY_PLUGINS/Docker.info
+sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Nova/Nova.info" $IMAGEFACTORY_PLUGINS/Nova.info
 
 # Add Imagefactory src dirs to imgfacdev.pth
 sudo sh -c "echo \"$IMAGEFACTORY_SRC\" > $PYTHON_PATH/site-packages/imgfacdev.pth"


### PR DESCRIPTION
A plugin that uses Nova Image Builder to create a base image using Nova on a remote Openstack infra instead of using Oz and libguestfs to do it locally.

This is the first cut and there are things that could be improved to make this less weird. Things like:
- pointing to the glance image in the base image body file
- somehow mapping all of the IDs that get created during build

I tested using a TDL name f19.tdl with the following content:

```
<template>
  <name>f19</name>
  <os>
    <name>Fedora</name>
    <version>19</version>
    <arch>x86_64</arch>
    <install type='url'>
      <url>http://download.fedoraproject.org/pub/fedora/linux/releases/19/Fedora/x86_64/os</url>
    </install>
  </os>
  <disk>
    <size>20</size>
  </disk>
</template>
```

...and launched the build from the command line with:
% imagefactory --debug base_image --file-parameter install_script fedora19.ks f19.tdl

---

Closes #324 
