### PR TITLE
Fixed OpenStack to work with Grizzly and later OpenStack releases 

### DIFF
--- a/imagefactory_plugins/OpenStack/OpenStack.py
+++ b/imagefactory_plugins/OpenStack/OpenStack.py
@@ -14,7 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import hashlib
 import logging
 import zope
 import libxml2
@@ -39,100 +38,6 @@ except ImportError:
        GLANCE_VERSION = 1
     except ImportError:
        raise ImageFactoryException("Glance client not found.")
-
-def keystone_authenticate(**kwargs):
-    user = kwargs.get('username')
-    pwd = kwargs.get('password')
-    tenant = kwargs.get('tenant')
-    url = kwargs.get('auth_url', 'http://127.0.0.1:35357/v2.0')
-
-    keystone = client.Client(username=user, password=pwd, tenant_name=tenant, auth_url=url)
-    return keystone.auth_ref
-
-def glance_upload_v2(image, auth_token=None, **kwargs):
-    if image is None:
-         raise ImageFactoryException("No image is provided")
-
-    url = kwargs.setdefault("url", "http://127.0.0.1:9292")
-    image_data = open(image, "r")
-
-    image_meta = {
-     'container_format': kwargs.setdefault('container_format', 'bare'),
-     'disk_format': kwargs.setdefault('disk_format', 'raw'),
-     'is_public': kwargs.setdefault('is_public', False),
-     'min_disk': kwargs.setdefault('min_disk', 0),
-     'min_ram': kwargs.setdefault('min_ram', 0),
-     'name': kwargs.setdefault('name', 'Factory Test Image'),
-     'data': image_data,
-    }
-
-    c = glance_client.Client('1', url, token=auth_token)
-    image_meta = c.images.create(**image_meta)
-    image_data.close()
-    return image_meta.id
-
-# Copied from Keystone's keystone/common/cms.py file.
-PKI_ANS1_PREFIX = 'MII'
-
-def is_ans1_token(token):
-    '''
-    thx to ayoung for sorting this out.
-
-    base64 decoded hex representation of MII is 3082
-    In [3]: binascii.hexlify(base64.b64decode('MII='))
-    Out[3]: '3082'
-
-    re: http://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf
-
-    pg4: For tags from 0 to 30 the first octet is the identfier
-    pg10: Hex 30 means sequence, followed by the length of that sequence.
-    pg5: Second octet is the length octet
-    first bit indicates short or long form, next 7 bits encode the number
-    of subsequent octets that make up the content length octets as an
-    unsigned binary int
-
-    82 = 10000010 (first bit indicates long form)
-    0000010 = 2 octets of content length
-    so read the next 2 octets to get the length of the content.
-
-    In the case of a very large content length there could be a requirement to
-    have more than 2 octets to designate the content length, therefore
-    requiring us to check for MIM, MIQ, etc.
-    In [4]: base64.b64encode(binascii.a2b_hex('3083'))
-    Out[4]: 'MIM='
-    In [5]: base64.b64encode(binascii.a2b_hex('3084'))
-    Out[5]: 'MIQ='
-    Checking for MI would become invalid at 16 octets of content length
-    10010000 = 90
-    In [6]: base64.b64encode(binascii.a2b_hex('3090'))
-    Out[6]: 'MJA='
-    Checking for just M is insufficient
-
-    But we will only check for MII:
-    Max length of the content using 2 octets is 7FFF or 32767
-    It's not practical to support a token of this length or greater in http
-    therefore, we will check for MII only and ignore the case of larger tokens
-    '''
-    return token[:3] == PKI_ANS1_PREFIX
-
-def glance_upload(image_filename, creds = {'auth_url': None, 'password': None, 'strategy': 'noauth', 'tenant': None, 'username': None},
-                  host = "0.0.0.0", port = "9292", token = None, name = 'Factory Test Image', disk_format = 'raw'):
-
-    image_meta = {'container_format': 'bare',
-     'disk_format': disk_format,
-     'is_public': True,
-     'min_disk': 0,
-     'min_ram': 0,
-     'name': name,
-     'properties': {'distro': 'rhel'}}
-
-
-    c = glance_client.Client(host=host, port=port,
-                             auth_tok=token, creds=creds)
-    image_data = open(image_filename, "r")
-    image_meta = c.add_image(image_meta, image_data)
-    image_data.close()
-    return image_meta['id']
 
 class OpenStack(object):
     zope.interface.implements(CloudDelegate)
@@ -187,19 +92,15 @@ class OpenStack(object):
         # Support openstack grizzly keystone authentication and glance upload
         if self.version == 2:
             if self.credentials_token is None:
-                auth_ref = keystone_authenticate(**self.credentials_dict)
-                if is_ans1_token(auth_ref.auth_token):
-                    self.credentials_token = hashlib.md5(auth_ref.auth_token).hexdigest()
-                else:
-                    self.credentials_token = auth_ref.auth_token
+                self.credentials_token = self.keystone_authenticate(**self.credentials_dict)
 
             provider_data['name']  = image_name
             provider_data['disk_format'] = disk_format
 
-            image_id = glance_upload_v2(input_image, self.credentials_token, **provider_data)
+            image_id = self.glance_upload_v2(input_image, self.credentials_token, **provider_data)
         else:
             # Also support backward compatible for folsom
-            image_id = glance_upload(input_image, creds = self.credentials_dict, token = self.credentials_token,
+            image_id = self.glance_upload(input_image, creds = self.credentials_dict, token = self.credentials_token,
                                      host=provider_data['glance-host'], port=provider_data['glance-port'],
                                      name=image_name, disk_format=disk_format)
 
@@ -291,6 +192,60 @@ class OpenStack(object):
             pass
 
         return None
+
+    def keystone_authenticate(self, **kwargs):
+        user = kwargs.get('username')
+        pwd = kwargs.get('password')
+        tenant = kwargs.get('tenant')
+        url = kwargs.get('auth_url', 'http://127.0.0.1:5000/v2.0')
+
+        keystone = client.Client(username=user, password=pwd, tenant_name=tenant, auth_url=url)
+        keystone.authenticate()
+        return keystone.auth_token
+
+    def glance_upload(self, image_filename, creds = {'auth_url': None, 'password': None, 'strategy': 'noauth', 'tenant': None, 'username': None},
+                      host = "0.0.0.0", port = "9292", token = None, name = 'Factory Test Image', disk_format = 'raw'):
+
+        image_meta = {'container_format': 'bare',
+         'disk_format': disk_format,
+         'is_public': True,
+         'min_disk': 0,
+         'min_ram': 0,
+         'name': name,
+         'properties': {'distro': 'rhel'}}
+
+
+        c = glance_client.Client(host=host, port=port,
+                                 auth_tok=token, creds=creds)
+        image_data = open(image_filename, "r")
+        image_meta = c.add_image(image_meta, image_data)
+        image_data.close()
+        return image_meta['id']
+
+    def glance_upload_v2(self, image, auth_token=None, **kwargs):
+        if image is None:
+             raise ImageFactoryException("No image is provided")
+
+        glance_host = kwargs.setdefault("glance-host", "127.0.0.1")
+        glance_port = kwargs.setdefault("glance-port", "9292")
+        glance_url = "http://%s:%s" % (glance_host, glance_port)
+
+        image_data = open(image, "r")
+
+        image_meta = {
+         'container_format': kwargs.setdefault('container_format', 'bare'),
+         'disk_format': kwargs.setdefault('disk_format', 'raw'),
+         'is_public': kwargs.setdefault('is_public', False),
+         'min_disk': kwargs.setdefault('min_disk', 0),
+         'min_ram': kwargs.setdefault('min_ram', 0),
+         'name': kwargs.setdefault('name', 'Factory Test Image'),
+         'data': image_data,
+        }
+
+        c = glance_client.Client('1', glance_url, token=auth_token)
+        image_meta = c.images.create(**image_meta)
+        image_data.close()
+        return image_meta.id
 
     # FIXME : cut/paste from RHEVMHelper.py, should refactor into a common utility class
     def check_qcow_size(self, filename):


### PR DESCRIPTION
This patch adds a check for which python-glanceclient version is installed.  The compatibility with the old version remains.  
