### PR TITLE
OpenStack plugin - Add support for glance custom properties

### DIFF
--- a/imagefactory_plugins/OpenStack/OpenStack.py
+++ b/imagefactory_plugins/OpenStack/OpenStack.py
@@ -240,6 +240,7 @@ class OpenStack(object):
          'min_ram': kwargs.setdefault('min_ram', 0),
          'name': kwargs.setdefault('name', 'Factory Test Image'),
          'data': image_data,
+         'properties': kwargs.setdefault('properties', '{}')
         }
 
         c = glance_client.Client('1', glance_url, token=auth_token)


### PR DESCRIPTION
Standard metadata fields - http://docs.openstack.org/grizzly/openstack-compute/admin/content/image-metadata.html
