### PR TITLE
add support for configurable VirtualSystemType value in vsphere OVF supp...

### DIFF
--- a/imagefactory_plugins/OVA/OVA.py
+++ b/imagefactory_plugins/OVA/OVA.py
@@ -72,7 +72,8 @@ class OVA(object):
         if self.parameters:
             params = ['ovf_cpu_count','ovf_memory_mb',
                       'rhevm_default_display_type','rhevm_description','rhevm_os_descriptor',
-                      'vsphere_product_name','vsphere_product_vendor_name','vsphere_product_version']
+                      'vsphere_product_name','vsphere_product_vendor_name','vsphere_product_version',
+                      'vsphere_virtual_system_type']
 
             for param in params:
                 if (self.parameters.get(param) and 

--- a/imagefactory_plugins/ovfcommon/ovfcommon.py
+++ b/imagefactory_plugins/ovfcommon/ovfcommon.py
@@ -367,13 +367,15 @@ class VsphereOVFDescriptor(object):
                  ovf_memory_mb,
                  vsphere_product_name,
                  vsphere_product_vendor_name,
-                 vsphere_product_version):
+                 vsphere_product_version,
+                 vsphere_virtual_system_type):
         self.disk = disk
         self.ovf_cpu_count = ovf_cpu_count
         self.ovf_memory_mb = ovf_memory_mb
         self.vsphere_product_name = vsphere_product_name
         self.vsphere_product_vendor_name = vsphere_product_vendor_name
         self.vsphere_product_version = vsphere_product_version
+        self.vsphere_virtual_system_type = vsphere_virtual_system_type
 
     def generate_ovf_xml(self):
         etroot = ElementTree.Element('Envelope')
@@ -472,7 +474,7 @@ class VsphereOVFDescriptor(object):
         etsystem.append(etvirtsysid)
 
         etvirtsystype = ElementTree.Element('vssd:VirtualSystemType')
-        etvirtsystype.text = 'vmx-07 vmx-08' #maybe not hardcode this?
+        etvirtsystype.text = self.vsphere_virtual_system_type 
         etsystem.append(etvirtsystype)
 
         etvirthwsec.append(etsystem)
@@ -763,7 +765,8 @@ class VsphereOVFPackage(OVFPackage):
                  ovf_memory_mb="4096",
                  vsphere_product_name="Product Name",
                  vsphere_product_vendor_name="Vendor Name",
-                 vsphere_product_version="1.0"):
+                 vsphere_product_version="1.0",
+                 vsphere_virtual_system_type="vmx-07 vmx-08"):
         disk = VsphereDisk(disk, base_image)
         super(VsphereOVFPackage, self).__init__(disk, path)
         self.disk_path = os.path.join(self.path, "disk.img")
@@ -774,6 +777,7 @@ class VsphereOVFPackage(OVFPackage):
         self.vsphere_product_name = vsphere_product_name
         self.vsphere_product_vendor_name = vsphere_product_vendor_name
         self.vsphere_product_version = vsphere_product_version
+        self.vsphere_virtual_system_type = vsphere_virtual_system_type
 
     def new_ovf_descriptor(self):
         return VsphereOVFDescriptor(self.disk,
@@ -781,7 +785,8 @@ class VsphereOVFPackage(OVFPackage):
                                     self.ovf_memory_mb,
                                     self.vsphere_product_name,
                                     self.vsphere_product_vendor_name,
-                                    self.vsphere_product_version)
+                                    self.vsphere_product_version,
+                                    self.vsphere_virtual_system_type)
 
     def copy_disk(self):
         copyfile_sparse(self.disk.path, self.disk_path)


### PR DESCRIPTION
...ort

The default value remains "vmx-07 vmx-08"

According to VMWare, this value can be a list of one or more vmx-## values
where the number corresponds to support for the following products:

10 - ESXi 5.5, Fusion 6.x, Workstation 10.x, Player 6.x
9 - ESXi 5.1, Fusion 5.x, Workstation 9.x, Player 5.x
8 - ESXi 5.0, Fusion 4.x, Workstation 8.x, Player 4.x
7 - ESXi/ESX 4.x, Fusion 3.x, Fusion 2.x, Workstation 7.x, Workstation 6.5.x,
    Player 3.x, Server 2.x
(earlier versions omitted)

Detalis taken from:

http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=1003746

This relates to BZ 1059456:

https://bugzilla.redhat.com/show_bug.cgi?id=1059456
