### PR TITLE
TinMan.py: Add the ability to override the default oz configuration file

### DIFF
--- a/imagefactory_plugins/TinMan/TinMan.py
+++ b/imagefactory_plugins/TinMan/TinMan.py
@@ -271,7 +271,12 @@ class TinMan(object):
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior
         self.oz_config = ConfigParser.SafeConfigParser()
-        if self.oz_config.read("/etc/oz/oz.cfg") != []:
+        if self.parameters.get("oz_config", None) != None:
+            oz_config_path = self.parameters.get("oz_config",None)
+        else:
+            # Default oz location
+            oz_config_path="/etc/oz/oz.cfg"
+        if self.oz_config.read(oz_config_path) != []:
             self.oz_config.set('paths', 'output_dir', self.app_config["imgdir"])
             if "oz_data_dir" in self.app_config:
                 self.oz_config.set('paths', 'data_dir', self.app_config["oz_data_dir"])


### PR DESCRIPTION
Add the ability to pass in an oz configuration file that defers from the one
in /etc/oz/oz.cfg which is useful for rpm-ostree-toolbox.  In particular, to
override the libvirt ram_size and default libvirt image when imagefactory
can create other images (rhev, vsphere) from qcow2.
