### PR TITLE
Imagefactory: TinMan

### DIFF
--- a/imagefactory_plugins/imagefactory-plugins.spec.in
+++ b/imagefactory_plugins/imagefactory-plugins.spec.in
@@ -78,6 +78,7 @@ License: ASL 2.0
 Requires: oz >= 0.12.0
 Requires: imagefactory-plugins
 Requires: imagefactory-plugin-api = 1.0
+Requires: python-simplejson
 
 %description TinMan
 An OS plugin to support Fedora OSes

--- a/imagefactory_plugins/ovfcommon/ovfcommon.py
+++ b/imagefactory_plugins/ovfcommon/ovfcommon.py
@@ -20,12 +20,13 @@ import os
 import tarfile
 from shutil import rmtree
 import uuid
-import struct
 import time
 import glob
 import tempfile
 from stat import *
 from imgfac.PersistentImageManager import PersistentImageManager
+from imgfac.FactoryUtils import check_qcow_size
+
 
 class RHEVOVFDescriptor(object):
     def __init__(self, img_uuid, vol_uuid, tpl_uuid, disk,
@@ -832,7 +833,7 @@ class RHEVMetaFile(object):
 class RHEVDisk(object):
     def __init__(self, path):
         self.path = path
-        self.qcow_size = self.check_qcow_size()
+        self.qcow_size = check_qcow_size()
         if self.qcow_size:
             self.vol_size=self.qcow_size
         else:
@@ -840,43 +841,6 @@ class RHEVDisk(object):
 
         self.raw_create_time = os.path.getctime(self.path)
         self.create_time = time.gmtime(self.raw_create_time)
-
-    def check_qcow_size(self):
-        # Detect if an image is in qcow format
-        # If it is, return the size of the underlying disk image
-        # If it isn't, return none
-
-        # For interested parties, this is the QCOW header struct in C
-        # struct qcow_header {
-        #    uint32_t magic;
-        #    uint32_t version;
-        #    uint64_t backing_file_offset;
-        #    uint32_t backing_file_size;
-        #    uint32_t cluster_bits;
-        #    uint64_t size; /* in bytes */
-        #    uint32_t crypt_method;
-        #    uint32_t l1_size;
-        #    uint64_t l1_table_offset;
-        #    uint64_t refcount_table_offset;
-        #    uint32_t refcount_table_clusters;
-        #    uint32_t nb_snapshots;
-        #    uint64_t snapshots_offset;
-        # };
-
-        # And in Python struct format string-ese
-        qcow_struct=">IIQIIQIIQQIIQ" # > means big-endian
-        qcow_magic = 0x514649FB # 'Q' 'F' 'I' 0xFB
-
-        f = open(self.path,"r")
-        pack = f.read(struct.calcsize(qcow_struct))
-        f.close()
-
-        unpack = struct.unpack(qcow_struct, pack)
-
-        if unpack[0] == qcow_magic:
-            return unpack[5]
-        else:
-            return None
 
 class VsphereDisk(object):
     def __init__(self, path, base_image):

--- a/imgfac/FactoryUtils.py
+++ b/imgfac/FactoryUtils.py
@@ -11,6 +11,7 @@ import re
 from imgfac.ImageFactoryException import ImageFactoryException
 import subprocess
 import logging
+import struct
 
 
 def launch_inspect_and_mount(diskfile, readonly=False):
@@ -233,3 +234,40 @@ def parameter_cast_to_bool(ival):
         if lower == 'yes' or lower == 'true' or lower == '1':
             return True
     return None
+
+def check_qcow_size(self, filename):
+    # Detect if an image is in qcow format
+    # If it is, return the size of the underlying disk image
+    # If it isn't, return None
+
+    # For interested parties, this is the QCOW header struct in C
+    # struct qcow_header {
+    #    uint32_t magic;
+    #    uint32_t version;
+    #    uint64_t backing_file_offset;
+    #    uint32_t backing_file_size;
+    #    uint32_t cluster_bits;
+    #    uint64_t size; /* in bytes */
+    #    uint32_t crypt_method;
+    #    uint32_t l1_size;
+    #    uint64_t l1_table_offset;
+    #    uint64_t refcount_table_offset;
+    #    uint32_t refcount_table_clusters;
+    #    uint32_t nb_snapshots;
+    #    uint64_t snapshots_offset;
+    # };
+
+    # And in Python struct format string-ese
+    qcow_struct=">IIQIIQIIQQIIQ" # > means big-endian
+    qcow_magic = 0x514649FB # 'Q' 'F' 'I' 0xFB
+
+    f = open(filename,"r")
+    pack = f.read(struct.calcsize(qcow_struct))
+    f.close()
+
+    unpack = struct.unpack(qcow_struct, pack)
+
+    if unpack[0] == qcow_magic:
+        return unpack[5]
+    else:
+        return None


### PR DESCRIPTION
Added ability to pass in overrides for oz configurations in the
format of a json/dict string. Example:

--parameter oz_overrides "{'libvirt': {'memory': 4096, 'image_type': 'kvm', 'cpus': 2}}"

Added python-simplejson Requires to imagefactory-plugins.spec.in