### PR TITLE
README: Update to f21, using the Cloud product

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,13 +18,13 @@ for more detail on creating a template. Note that a template is **not** tied to
 a specific cloud. 
 
     <template>
-        <name>f12jeos</name>
+        <name>f21</name>
         <os>
             <name>Fedora</name>
-            <version>12</version>
+            <version>21</version>
             <arch>x86_64</arch>
             <install type='iso'>
-                <iso>http://download.fedoraproject.org/pub/fedora/linux/releases/12/Fedora/x86_64/os/</iso>
+                <iso>http://download.fedoraproject.org/pub/fedora/linux/releases/21/Cloud/x86_64/os/</iso>
             </install>
             <rootpw>p@55word!</rootpw>
         </os>


### PR DESCRIPTION
Enough time has passed that I could conveniently just use Ctrl-t in
Emacs to transpose the version number digits!  It's the little
things in life.

Also, use the Cloud product.
