### PR TITLE
Docker: Default CMD to bash

### DIFF
--- a/imagefactory_plugins/Docker/Docker.py
+++ b/imagefactory_plugins/Docker/Docker.py
@@ -57,7 +57,7 @@ class Docker(object):
   "comment": "{commentstring}",
   "created": "{createdtime}",
   "container_config": {{
-    "Cmd": null,
+    "Cmd": ["/bin/bash"],
     "Env": null,
     "StdinOnce": false,
     "OpenStdin": false,


### PR DESCRIPTION
This is what Debian/Ubuntu do, and it is kind of friendly.  We're
assuming this base image container has bash, which seems reasonable
for "fat" base images.

Anyone can override this of course with derived images, which is kind
of the point.

(Note: totally untested)