### PR TITLE
add the import of oz.RHEL_7 to avoid syntax error

### DIFF
--- a/imagefactory_plugins/EC2/EC2CloudOSHelpers.py
+++ b/imagefactory_plugins/EC2/EC2CloudOSHelpers.py
@@ -16,6 +16,7 @@ import logging
 from imgfac.ImageFactoryException import ImageFactoryException
 import oz.RHEL_5
 import oz.RHEL_6
+import oz.RHEL_7
 import oz.Fedora
 
 


### PR DESCRIPTION
The existing code has utilized "oz.RHEL_7" but no where to import, please add.