### PR TITLE
Fix process name in status section of init file.

### DIFF
--- a/scripts/imagefactoryd
+++ b/scripts/imagefactoryd
@@ -125,7 +125,7 @@ case "$1" in
 	RETVAL=$?
 	;;
   status)
-        status imagefactory
+        status $prog
 	RETVAL=$?
         ;;
   *)


### PR DESCRIPTION
Since the process name is incorrectly hardcoded inside the init file,
the status command always returned “imagefactory is stopped”. This
commit feeds the prog variable defined to the status command and the
result is “imagefactoryd (pid  210) is running...”