### PR TITLE
Cleanups for development setup script.

### DIFF
--- a/scripts/imagefactory_dev_setup.sh
+++ b/scripts/imagefactory_dev_setup.sh
@@ -7,26 +7,16 @@ IMAGEFACTORY_PLUGINS=/etc/imagefactory/plugins.d/
 WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 IMAGEFACTORY_SRC=$(dirname "$WORKING_DIR")
 
-sudo rm -rf $IMAGEFACTORY_PLUGINS/*
+sudo mkdir -p $IMAGEFACTORY_PLUGINS
+sudo rm -f $IMAGEFACTORY_PLUGINS/*.info
 
 # Create symlinks to src plugins
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/EC2/EC2.info" $IMAGEFACTORY_PLUGINS/EC2.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/TinMan/TinMan.info" $IMAGEFACTORY_PLUGINS/TinMan.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/MockOS/MockOS.info" $IMAGEFACTORY_PLUGINS/MockOS.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/OpenStack/OpenStack.info" $IMAGEFACTORY_PLUGINS/OpenStack.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/MockCloud/MockCloud.info" $IMAGEFACTORY_PLUGINS/MockCloud.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/RHEVM/RHEVM.info" $IMAGEFACTORY_PLUGINS/RHEVM.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/vSphere/vSphere.info" $IMAGEFACTORY_PLUGINS/vSphere.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Rackspace/Rackspace.info" $IMAGEFACTORY_PLUGINS/Rackspace.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/OVA/OVA.info" $IMAGEFACTORY_PLUGINS/OVA.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/IndirectionCloud/IndirectionCloud.info" $IMAGEFACTORY_PLUGINS/IndirectionCloud.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Docker/Docker.info" $IMAGEFACTORY_PLUGINS/Docker.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/Nova/Nova.info" $IMAGEFACTORY_PLUGINS/Nova.info
-sudo ln -s "$IMAGEFACTORY_SRC/imagefactory_plugins/HyperV/HyperV.info" $IMAGEFACTORY_PLUGINS/HyperV.info
+for plugin in $IMAGEFACTORY_SRC/imagefactory_plugins/*/*.info; do
+    sudo ln -s "$plugin" $IMAGEFACTORY_PLUGINS
+done
 
 # Add Imagefactory src dirs to imgfacdev.pth
 sudo sh -c "echo \"$IMAGEFACTORY_SRC\" > $PYTHON_PATH/site-packages/imgfacdev.pth"
-sudo sh -c "echo \"$IMAGEFACTORY_SRC/imagefactory_plugins\" >> $PYTHON_PATH/site-packages/imgfacdev.pth"
 
 echo "******************************************************"
 echo "**    Imagefactory Development Environment Setup    **"


### PR DESCRIPTION
1. Install all plugins instead of just the named ones. It's very easy to
   forget listing the plugin here when adding a new plugin.

2. We don't need to add imagefactory_plugins to imgfacdev.pth because
   the plugins are imported via the "imagefactory_plugins" package from
   the root of the source tree (which is already added).