### PR TITLE
Don't load the OS helper for target_image.

### DIFF
--- a/imagefactory_plugins/EC2/EC2.py
+++ b/imagefactory_plugins/EC2/EC2.py
@@ -100,7 +100,6 @@ class EC2(object):
             self.template = template
             self.target = target
             self.tdlobj = oz.TDL.TDL(xmlstring=self.template.xml, rootpw_required=self.app_config["tdl_require_root_pw"])
-            self._get_os_helper()
             # Add in target specific content
             self.add_target_content()
 


### PR DESCRIPTION
Don't load the OS helper plugin in the target_image step. It's not
needed there, and this way we can support a target image for OSs
that are not recognized (e.g. CentOS).