### PR TITLE
Change the VMware disk controller to PVSCSI

### DIFF
--- a/imagefactory_plugins/vSphere/VSphereHelper.py
+++ b/imagefactory_plugins/vSphere/VSphereHelper.py
@@ -119,7 +119,7 @@ class VSphereHelper:
         vm_devices = []
 
         # Create a disk controller
-        controller = self.create_controller("VirtualLsiLogicController")
+        controller = self.create_controller("ParaVirtualSCSIController")
         vm_devices.append(controller)
 
         ds_to_use = None


### PR DESCRIPTION
The mptspi and mptscsih kernel modules, needed for the older LSI Logic
controller, have been deprecated in CentOS 6.8 and 7.2 (see issue #386)

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/6.8_Technical_Notes/chap-Red_Hat_Enterprise_Linux-6.8_Technical_Notes-Deprecated_Functionality.html

https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/7.2_Release_Notes/chap-Red_Hat_Enterprise_Linux-7.2_Release_Notes-Deprecated_Functionality.html#idp5588384
