### PR TITLE
Add "ec2_image_format" configuration variable.

### DIFF
--- a/imgfac/FactoryUtils.py
+++ b/imgfac/FactoryUtils.py
@@ -236,6 +236,19 @@ def parameter_cast_to_bool(ival):
     return None
 
 
+def disk_image_format(inputfn):
+    # Return the format of a disk image. If the format is not understood, return None.
+    try:
+       cmd = [ 'qemu-img', 'info', inputfn ]
+       stdout, _, _ = subprocess_check_output(cmd)
+       for line in stdout.splitlines():
+           key, value = line.split(': ')
+           if key == 'file format':
+               return value
+    except ImageFactoryException:
+        pass
+
+
 def disk_image_capacity(filename):
     # Return the actual virtual size of a disk image file as visible to the guest
     # Meant to be used to safely determine the guest-visible size of


### PR DESCRIPTION
This allows you to use the EC2 VM import service. You would set the
"ec2_image_format" configuration variable to a supported format, and then
pass

  --parameter skip_ec2_modifications true

to the "target_image" command. The result is an image that can be used with
the EC2 image import service.

Note that in theory this change is not strictly necessary, as the VM import
service does support the RAW format. However RAW images are very large and
in our case it's not a practical format for our users to download. So a
sparse format like VMDK or VHD is preferred.

[1] http://docs.aws.amazon.com/vm-import/latest/userguide/vmimport-image-import.html