### PR TITLE
Use vmware_desktop in the Vagrant image metadata

### DIFF
--- a/imagefactory_plugins/ovfcommon/ovfcommon.py
+++ b/imagefactory_plugins/ovfcommon/ovfcommon.py
@@ -1187,7 +1187,7 @@ end
         vmxff.write('')
         vmxff.close()
 
-        metadata_json = '{"provider": "vmware_fusion"}'
+        metadata_json = '{"provider": "vmware_desktop"}'
         metadata_json_path = os.path.join(self.path, "metadata.json")
         mj = open(metadata_json_path, 'w')
         mj.write(metadata_json)


### PR DESCRIPTION
Using vmware_desktop instead of wmware_fusion allows us to target both
VMware Workstation and VMware Fusion with the same Vagrant image.

Fix for issue #390.