### PR TITLE
ovfcommon: supporting OVAs with subdirectories

### DIFF
--- a/imagefactory_plugins/ovfcommon/ovfcommon.py
+++ b/imagefactory_plugins/ovfcommon/ovfcommon.py
@@ -794,7 +794,9 @@ class OVFPackage(object):
         tar = tarfile.open(ovapath, 'w')
         cwd = os.getcwd()
         os.chdir(self.path)
-        files = glob.glob('*')
+        files = [os.path.join(r, f)[2::]
+                 for r, d, fs in os.walk(".")
+                 for f in fs]
         files.remove(os.path.basename(ovapath))
 
         # per specification, the OVF descriptor must be first in


### PR DESCRIPTION
The standard requires the .ovf file to be the first in the ova archive
for streaming issues, however, if an ova is created with subdirectories,
glob.glob("*") expands to the toplevel directories, creating an ova
with a wrong file order.

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>