### PR TITLE
Protect against parameters in main request_data

### DIFF
--- a/imgfac/rest/RESTv2.py
+++ b/imgfac/rest/RESTv2.py
@@ -126,6 +126,11 @@ def create_image(image_collection, base_image_id=None, target_image_id=None):
             request_data = form_data.get(image_type)
         if(not request_data):
             raise HTTPResponse(status=400, output='%s not found in request.' % image_type)
+        for rdatakey in request_data.keys():
+            if rdatakey not in ['base_image_id', 'target_image_id', 'template',
+                                'parameters', 'provider', 'credentials',
+                                'target']:
+                raise HTTPResponse(status=400, output='Unexpected key %s found in request, maybe put in parameters?' % rdatakey)
 
         req_base_img_id = request_data.get('base_image_id')
         req_target_img_id = request_data.get('target_image_id')


### PR DESCRIPTION
This should offer some protection against callers putting keys incorrectly
in the request_data instead of request_data['parameters'].
This avoids getting REST users annoyed because imagefactory "silently discards
parameters".

Signed-off-by: Patrick Uiterwijk <puiterwijk@redhat.com>