### PR TITLE
Fixed parse_command call to support oz versions 0.13 or greater

### DIFF
--- a/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
+++ b/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
@@ -271,7 +271,12 @@ class IndirectionCloud(object):
         repositorieslist = doc.xpath('/template/repositories/repository')
         self.tdlobj._add_repositories(repositorieslist)
 
-        self.tdlobj.commands = self.tdlobj._parse_commands()
+        try:
+            # oz ver < 0.13
+            self.tdlobj.commands = self.tdlobj._parse_commands()
+        except TypeError:
+            # oz ver >= 0.13
+            self.tdlobj.commands = self.tdlobj._parse_commands('/template/commands')
 
 
     def _init_oz(self):


### PR DESCRIPTION
Kept previous call for backwards compatibility

Change in oz:
https://github.com/clalancette/oz/commit/d2f8cd635f94235abccfba96e95b212a557656d6