### PR TITLE
use full path on killall to make f27 systemd happy

### DIFF
--- a/conf/imagefactoryd.service
+++ b/conf/imagefactoryd.service
@@ -5,6 +5,6 @@ After=libvirtd.service
 [Service]
 Type=forking
 ExecStart=/usr/bin/imagefactoryd 
-ExecStop=killall imagefactoryd
+ExecStop=/usr/bin/killall imagefactoryd
 PIDFile=/var/run/imagefactoryd.pid
 LOCKFile=/var/lock/subsys/imagefactoryd


### PR DESCRIPTION
With systemd-234 in Fedora 27, it complains about the service file for imagefactoryd saying that 'killall' needs to be an absolute path. When I patch the file by hand, it works and systemctl stops complaining.