### PR TITLE
Clean up qemu images if build cancelled

### DIFF
--- a/imagefactory_plugins/Docker/Docker.py
+++ b/imagefactory_plugins/Docker/Docker.py
@@ -515,3 +515,6 @@ class Docker(object):
 
     def builder_did_create_target_image(self, builder, target, image_id, template, parameters):
         raise ImageFactoryException("builder_did_create_target_image called in Docker plugin - this should never happen")
+
+    def abort(self):
+        pass


### PR DESCRIPTION
Currently if a build is cancelled in Koji, Koji sends a SIGINT to child processes. Imagefactory is not handling this gracefully; it will not attempt to clean up any QEMU process before exiting, leading to zombie instances. This change adds a signal handler to the Builder class (as Koji imports BuildDispatcher directly), and calls the already existing abort() methods for clean up.