### PR TITLE
ApplicationConfiguration.py: drop encoding from json.load

### DIFF
--- a/imgfac/ApplicationConfiguration.py
+++ b/imgfac/ApplicationConfiguration.py
@@ -160,7 +160,7 @@ class ApplicationConfiguration(Singleton):
                     return new_dict
 
                 config_file = open(configuration.config)
-                uconfig = json.load(config_file, encoding="utf-8")
+                uconfig = json.load(config_file)
                 config_file.close()
                 defaults = uconfig
                 print(defaults)


### PR DESCRIPTION
The encoding option was deprecated in Python 3.1 and as of 3.9 it's dropped completely

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>