### PR TITLE
Add support for CentOS 8 and RHEL 8

### DIFF
--- a/imagefactory_plugins/Nova/Nova.info
+++ b/imagefactory_plugins/Nova/Nova.info
@@ -1,7 +1,8 @@
 {
     "type": "os",
     "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null], ["RHEL-7", null, null],
-                 ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null], ["Windows", null, null]
+                 ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null], ["Windows", null, null],
+                 ["RHEL-8", null, null], ["CentOS-8", null, null], ["CentOS-7", null, null]
                ],
     "description": "Plugin to support building OS base images using OpenStack Nova.",
     "maintainer": {

--- a/imagefactory_plugins/TinMan/TinMan.info
+++ b/imagefactory_plugins/TinMan/TinMan.info
@@ -3,7 +3,8 @@
     "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null],
                  ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null],
                  ["ScientificLinux-6", null, null], ["ScientificLinux-5", null, null], ["OpenSUSE", null, null],
-                 [ "RHEL-7", null, null ], [ "CentOS-7", null, null ], [ "ScientificLinux-7", null, null ] ],
+                 [ "RHEL-7", null, null ], [ "CentOS-7", null, null ], [ "ScientificLinux-7", null, null ],
+                 [ "RHEL-8", null, null ], [ "CentOS-8", null, null ] ],
     "description": "Plugin to support most Oz customize capable guest types",
     "maintainer": {
         "name": "Red Hat, Inc.",


### PR DESCRIPTION
Allow specifying CentOS 8 and RHEL 8 for TinMan. This won't work without [this patch](https://github.com/clalancette/oz/pull/270) for oz, though.

Also adds `CentOS-7` to Nova, which was missing.