### PR TITLE
Replaced Thread.isAlive with Thread.is_alive

### DIFF
--- a/imagefactory
+++ b/imagefactory
@@ -122,7 +122,7 @@ class Application(Singleton):
             for builder_id in builder_dict:
                 # If the build or push worker thread has already exited we do nothing
                 # builder classes should always cleanup before exiting the thread-starting methods
-                if builder_dict[builder_id].builder_thread and builder_dict[builder_id].builder_thread.isAlive():
+                if builder_dict[builder_id].builder_thread and builder_dict[builder_id].builder_thread.is_alive():
                     try:
                         logging.debug("Executing abort method for builder id (%s)" % (builder_id))
                         builder_dict[builder_id].abort()

--- a/imagefactory_plugins/Docker/Docker.py
+++ b/imagefactory_plugins/Docker/Docker.py
@@ -366,7 +366,7 @@ class Docker(object):
                     self.log.error("WARNING: Could not unmount guest at (%s) - may still be mounted" % (tempdir) )
             if fuse_thread:
                 fuse_thread.join(30.0)
-                if fuse_thread.isAlive():
+                if fuse_thread.is_alive():
                     self.log.error("Guestfs local mount thread is still active - FUSE filesystem still mounted at (%s)" % (tempdir) )
 
         if wrap_metadata:

--- a/imagefactoryd
+++ b/imagefactoryd
@@ -94,7 +94,7 @@ class Application(Singleton):
             for builder_id in builder_dict:
                 # If the build or push worker thread has already exited we do nothing
                 # builder classes should always cleanup before exiting the thread-starting methods
-                if builder_dict[builder_id].builder_thread and builder_dict[builder_id].builder_thread.isAlive():
+                if builder_dict[builder_id].builder_thread and builder_dict[builder_id].builder_thread.is_alive():
                     try:
                         logging.debug("Executing abort method for builder id (%s)" % (builder_id))
                         builder_dict[builder_id].abort()

--- a/tests/testReservationManager.py
+++ b/tests/testReservationManager.py
@@ -140,7 +140,7 @@ class testReservationManager(unittest.TestCase):
         for job in job_threads:
             job.start()
         for job in job_threads:
-            if job.isAlive():
+            if job.is_alive():
                 job.join()
         #self.log.info(job_output)
         self.assertEqual((3 * job_number * len(ReservationManager().queues)), len(job_output))


### PR DESCRIPTION
Python 3.9 has removed the deprecated Thread.isAlive method.