### PR TITLE
Add support for prolinux

### DIFF
--- a/imagefactory_plugins/Nova/Nova.info
+++ b/imagefactory_plugins/Nova/Nova.info
@@ -1,6 +1,6 @@
 {
     "type": "os",
-    "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null], ["RHEL-7", null, null],
+    "targets": [ ["Fedora", null, null], ["ProLinux", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null], ["RHEL-7", null, null],
                  ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null], ["Windows", null, null]
                ],
     "description": "Plugin to support building OS base images using OpenStack Nova.",

--- a/imagefactory_plugins/TinMan/TinMan.info
+++ b/imagefactory_plugins/TinMan/TinMan.info
@@ -1,6 +1,6 @@
 {
     "type": "os",
-    "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null],
+    "targets": [ ["Fedora", null, null], ["ProLinux", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null],
                  ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null],
                  ["ScientificLinux-6", null, null], ["ScientificLinux-5", null, null], ["OpenSUSE", null, null],
                  [ "RHEL-7", null, null ], [ "CentOS-7", null, null ], [ "ScientificLinux-7", null, null ] ],


### PR DESCRIPTION
Adding this support is to allow specifying 'ProLinux' for TinMan and Nova. This won't work without [this patch](https://github.com/clalancette/oz/pull/285) for oz.
