### PR TITLE
OzException has no attribute 'message'

### DIFF
--- a/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
+++ b/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
@@ -302,7 +302,7 @@ class IndirectionCloud(object):
         except libvirtError as e:
             raise ImageFactoryException("Cannot connect to libvirt.  Make sure libvirt is running. [Original message: %s]" %  e.message)
         except OzException as e:
-            if "Unsupported" in e.message:
+            if "Unsupported" in str(e):
                 raise ImageFactoryException("TinMan plugin does not support distro (%s) update (%s) in TDL" % (self.tdlobj.distro, self.tdlobj.update) )
             else:
                 raise e

--- a/imagefactory_plugins/TinMan/TinMan.py
+++ b/imagefactory_plugins/TinMan/TinMan.py
@@ -406,7 +406,7 @@ class TinMan(object):
         except libvirtError as e:
             raise ImageFactoryException("Cannot connect to libvirt.  Make sure libvirt is running. [Original message: %s]" %  e.message)
         except OzException as e:
-            if "Unsupported" in e.message:
+            if "Unsupported" in str(e):
                 raise ImageFactoryException("TinMan plugin does not support distro (%s) update (%s) in TDL" % (self.tdlobj.distro, self.tdlobj.update) )
             else:
                 raise e


### PR DESCRIPTION
OzException has no attribute 'message', so imagefactory plugins may fail while handling an Oz exception:

```
Exception encountered in _build_image_from_template thread
'OzException' object has no attribute 'message'
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/imagefactory_plugins/TinMan/TinMan.py", line 403, in init_guest
    self.guest = oz.GuestFactory.guest_factory(self.tdlobj, self.oz_config, install_script_name)
  File "/usr/lib/python3.6/site-packages/oz/GuestFactory.py", line 105, in guest_factory
    diskbus, macaddress)
  File "/usr/lib/python3.6/site-packages/oz/RHEL_8.py", line 76, in get_class
    macaddress)
  File "/usr/lib/python3.6/site-packages/oz/RHEL_8.py", line 39, in __init__
    False)
  File "/usr/lib/python3.6/site-packages/oz/RedHat.py", line 729, in __init__
    initrdtype, macaddress)
  File "/usr/lib/python3.6/site-packages/oz/RedHat.py", line 46, in __init__
    url_allowed, macaddress)
  File "/usr/lib/python3.6/site-packages/oz/Linux.py", line 39, in __init__
    url_allowed, macaddress)
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 1332, in __init__
    url_allowed, macaddress)
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 250, in __init__
    self.connect_to_libvirt()
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 128, in connect_to_libvirt
    self._discover_libvirt_bridge()
  File "/usr/lib/python3.6/site-packages/oz/Guest.py", line 111, in _discover_libvirt_bridge
    raise oz.OzException.OzException("Could not find a libvirt bridge.  Please run 'virsh net-start default' to start the default libvirt network, or see http://github.com/clalancette/oz/wiki/Oz-Network-Configuration for more information")
oz.OzException.OzException: Could not find a libvirt bridge.  Please run 'virsh net-start default' to start the default libvirt network, or see http://github.com/clalancette/oz/wiki/Oz-Network-Configuration for more information

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/imgfac/Builder.py", line 135, in _build_image_from_template
    self.os_plugin.create_base_image(self, template, parameters)
  File "/usr/lib/python3.6/site-packages/imagefactory_plugins/TinMan/TinMan.py", line 320, in create_base_image
    self._init_oz()
  File "/usr/lib/python3.6/site-packages/imagefactory_plugins/TinMan/TinMan.py", line 297, in _init_oz
    self.init_guest()
  File "/usr/lib/python3.6/site-packages/imagefactory_plugins/TinMan/TinMan.py", line 409, in init_guest
    if "Unsupported" in e.message:
AttributeError: 'OzException' object has no attribute 'message'
check image results: FAILED
ABORT called in TinMan plugin
```