### PR TITLE
imagefactory_plugins.Docker: preserve security.capability xattrs

### DIFF
--- a/imagefactory_plugins/Docker/Docker.py
+++ b/imagefactory_plugins/Docker/Docker.py
@@ -329,7 +329,7 @@ class Docker(object):
             #        to allow selective inclusion is broken
             # TODO: Follow up with tar maintainers and docker image creators to find out what
             #       if any xattrs we really need to capture here
-            tarcmd = [ 'tar',  '-cf', builder.target_image.data, '-C', tempdir ]
+            tarcmd = [ 'tar',  '-cf', builder.target_image.data, '--xattrs', '--xattrs-include=security.capability', '-C', tempdir ]
             # User may pass in a comma separated list of additional options to the tar command
             tar_options = parameters.get('tar_options', None)
             if tar_options:


### PR DESCRIPTION
Default to preserving the "security.capability" xattr on files.  Other extended attributes will continue to be ignored by default.