### PR TITLE
Use GOARCH value for arm32 bit.

### DIFF
--- a/imagefactory_plugins/Docker/Docker.py
+++ b/imagefactory_plugins/Docker/Docker.py
@@ -398,7 +398,7 @@ class Docker(object):
             if arch == "x86_64":
                 arch = "amd64"
             elif arch == "armv7hl":
-                arch = "armhfp"
+                arch = "arm"
             tdict = { }
             tdict['commentstring'] = parameters.get('comment', 'Created by Image Factory')
             tdict['os'] = parameters.get('os', 'linux')


### PR DESCRIPTION
For arm32 bit we need to use the GOARCH[1] specification

and replace armhfp by arm otherwise client using the
container registry manifest list feature will not be able
to pull arm32 bit images.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1997789

[1] - https://golang.org/doc/install/source#environment

Signed-off-by: Clement Verna <cverna@tutanota.com>