### PR TITLE
Update TinMan info to know about RHEL 8 and 9 and derivatives

### DIFF
--- a/imagefactory_plugins/TinMan/TinMan.info
+++ b/imagefactory_plugins/TinMan/TinMan.info
@@ -3,7 +3,10 @@
     "targets": [ ["Fedora", null, null], ["RHEL-6", null, null], ["RHEL-5", null, null],
                  ["Ubuntu", null, null], ["CentOS-6", null, null], ["CentOS-5", null, null],
                  ["ScientificLinux-6", null, null], ["ScientificLinux-5", null, null], ["OpenSUSE", null, null],
-                 [ "RHEL-7", null, null ], [ "CentOS-7", null, null ], [ "ScientificLinux-7", null, null ] ],
+                 [ "RHEL-7", null, null ], [ "CentOS-7", null, null ], [ "ScientificLinux-7", null, null ],
+                 [ "RHEL-8", null, null ], [ "CentOS-8", null, null ], [ "Rocky-8", null, null ],
+                 [ "RHEL-9", null, null ], [ "CentOS-9", null, null ], [ "Rocky-9", null, null ] 
+               ],
     "description": "Plugin to support most Oz customize capable guest types",
     "maintainer": {
         "name": "Red Hat, Inc.",


### PR DESCRIPTION
Hi there,

I've been working on building some images for Rocky Linux 9 using the tinman plugin and found the info file needed a bit of a touch up for EL8 and EL9.

Best,
Neil Hanlon