### PR TITLE
WIP TinMan.py: adjust to oz generate_diskimage size unit changing

### DIFF
--- a/imagefactory_plugins/TinMan/TinMan.py
+++ b/imagefactory_plugins/TinMan/TinMan.py
@@ -336,7 +336,8 @@ class TinMan(object):
                 try:
                     disksize=getattr(self.guest, "disksize")
                 except AttributeError:
-                    disksize = 10
+                    # 10 GiB
+                    disksize = 10*1024*1024*1024
                 self.guest.generate_diskimage(size = disksize)
                 # TODO: If we already have a base install reuse it
                 #  subject to some rules about updates to underlying repo


### PR DESCRIPTION
In https://github.com/clalancette/oz/pull/310 I'm proposing we change the unit of the `generate_diskimage` method's size arg from gibibytes to bytes. This needs adjusting to match that. Don't merge this unless and until that PR is merged.