### PR TITLE
Update for Python 3.12 compatibility and backport bottle CVE-2022-31799 fix

### DIFF
--- a/imagefactory_plugins/EC2/EC2.py
+++ b/imagefactory_plugins/EC2/EC2.py
@@ -61,7 +61,11 @@ class EC2(object):
         self.log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
         config_obj = ApplicationConfiguration()
         self.app_config = config_obj.configuration
-        self.oz_config = configparser.SafeConfigParser()
+        try:
+            self.oz_config = configparser.SafeConfigParser()
+        except AttributeError:
+            # SafeConfigParser was deprecated in Python 3.2
+            self.oz_config = configparser.ConfigParser()
         self.oz_config.read("/etc/oz/oz.cfg")
         self.oz_config.set('paths', 'output_dir', self.app_config["imgdir"])
         self.guest = None

--- a/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
+++ b/imagefactory_plugins/IndirectionCloud/IndirectionCloud.py
@@ -282,7 +282,11 @@ class IndirectionCloud(object):
     def _init_oz(self):
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior
-        self.oz_config = configparser.SafeConfigParser()
+        try:
+            self.oz_config = configparser.SafeConfigParser()
+        except AttributeError:
+            # SafeConfigParser was deprecated in Python 3.2
+            self.oz_config = configparser.ConfigParser()
         if self.oz_config.read("/etc/oz/oz.cfg") != []:
             self.oz_config.set('paths', 'output_dir', self.app_config["imgdir"])
             if "oz_data_dir" in self.app_config:

--- a/imagefactory_plugins/Nova/Nova.py
+++ b/imagefactory_plugins/Nova/Nova.py
@@ -28,7 +28,11 @@ from novaimagebuilder.StackEnvironment import StackEnvironment
 from time import sleep
 from base64 import b64decode
 #TODO: remove dependency on Oz
-from configparser import SafeConfigParser
+try:
+    from configparser import SafeConfigParser as ConfigParser
+except AttributeError:
+    # SafeConfigParser was deprecated in Python 3.2
+    from configparser import ConfigParser
 from oz.TDL import TDL
 import oz.GuestFactory
 
@@ -438,7 +442,7 @@ class Nova(object):
         return confirmation
 
     def _oz_config(self, private_key_file):
-        config = SafeConfigParser()
+        config = ConfigParser()
         if config.read("/etc/oz/oz.cfg"):
             config.set('paths', 'output_dir', self.app_config['imgdir'])
             config.set('paths', 'sshprivkey', private_key_file)

--- a/imagefactory_plugins/Rackspace/Rackspace.py
+++ b/imagefactory_plugins/Rackspace/Rackspace.py
@@ -64,7 +64,11 @@ class Rackspace(object):
         self.log = logging.getLogger('%s.%s' % (__name__, self.__class__.__name__))
         config_obj = ApplicationConfiguration()
         self.app_config = config_obj.configuration
-        self.oz_config = configparser.SafeConfigParser()
+        try:
+            self.oz_config = configparser.SafeConfigParser()
+        except AttributeError:
+            # SafeConfigParser was deprecated in Python 3.2
+            self.oz_config = configparser.ConfigParser()
         self.oz_config.read("/etc/oz/oz.cfg")
         self.oz_config.set('paths', 'output_dir', self.app_config["imgdir"])
         self.active_image = None

--- a/imagefactory_plugins/TinMan/TinMan.py
+++ b/imagefactory_plugins/TinMan/TinMan.py
@@ -269,7 +269,11 @@ class TinMan(object):
 
         # populate a config object to pass to OZ; this allows us to specify our
         # own output dir but inherit other Oz behavior
-        self.oz_config = configparser.SafeConfigParser()
+        try:
+            self.oz_config = configparser.SafeConfigParser()
+        except AttributeError:
+            # SafeConfigParser was deprecated in Python 3.2
+            self.oz_config = configparser.ConfigParser()
         if self.oz_config.read("/etc/oz/oz.cfg") != []:
             if self.parameters.get("oz_overrides", None) != None:
                 oz_overrides = json.loads(self.parameters.get("oz_overrides",None).replace("'", "\""))


### PR DESCRIPTION
This adjusts for things removed from Python 3.12, and backports the fix for CVE-2022-31799 to the bundled bottle.py.